### PR TITLE
Implement parser for Bash-based tools

### DIFF
--- a/clip-parse/README.md
+++ b/clip-parse/README.md
@@ -1,0 +1,3 @@
+# Command Line Interface Pages parser
+
+Command Line Interface Pages parser.

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -718,6 +718,7 @@ __parser_output_token_value() {
     declare tokens="$1"
     declare index="$2"
 
+    # shellcheck disable=2155
     declare count="$(__parser_output_token_count "$tokens")"
     declare -i line=0
     declare -i current_index=0
@@ -744,6 +745,7 @@ __parser_output_token_type() {
     declare tokens="$1"
     declare index="$2"
 
+    # shellcheck disable=2155
     declare count="$(__parser_output_token_count "$tokens")"
     declare -i line=0
     declare -i current_index=0

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -885,7 +885,7 @@ __parser_tokens__all_unbalanced() {
     done
 }
 
-# __parser_tokens__count <tokens>
+# parser_tokens__count <tokens>
 # Output token count.
 #
 # Output:
@@ -893,7 +893,7 @@ __parser_tokens__all_unbalanced() {
 #
 # Return:
 #   - 0 always
-__parser_tokens__count() {
+parser_tokens__count() {
     declare in_tokens="$1"
 
     # shellcheck disable=2155
@@ -903,7 +903,7 @@ __parser_tokens__count() {
     echo -n "$((count / 2))"
 }
 
-# __parser_tokens__value <tokens> <index>
+# parser_tokens__value <tokens> <index>
 # Output a token value.
 #
 # Output:
@@ -912,14 +912,14 @@ __parser_tokens__count() {
 # Return:
 #   - 0 <index> is valid
 #   - $PARSER_INVALID_ARGUMENT_CODE otherwise
-__parser_tokens__value() {
+parser_tokens__value() {
     declare in_tokens="$1"
     declare in_index="$2"
 
     ((in_index < 0)) && return "$PARSER_INVALID_ARGUMENT_CODE"
 
     # shellcheck disable=2155
-    declare count="$(__parser_tokens__count "$in_tokens")"
+    declare count="$(parser_tokens__count "$in_tokens")"
     ((in_index >= count)) && return "$PARSER_INVALID_ARGUMENT_CODE"
 
     declare -i line=0
@@ -935,7 +935,7 @@ __parser_tokens__value() {
     [[ -n "${tokens_array[line + 1]}" ]] && echo -n "${tokens_array[line + 1]}"
 }
 
-# __parser_tokens__type <tokens> <index>
+# parser_tokens__type <tokens> <index>
 # Output a token type.
 #
 # Output:
@@ -944,14 +944,14 @@ __parser_tokens__value() {
 # Return:
 #   - 0 <index> is valid
 #   - $PARSER_INVALID_ARGUMENT_CODE otherwise
-__parser_tokens__type() {
+parser_tokens__type() {
     declare in_tokens="$1"
     declare in_index="$2"
 
     ((in_index < 0)) && return "$PARSER_INVALID_ARGUMENT_CODE"
 
     # shellcheck disable=2155
-    declare count="$(__parser_tokens__count "$in_tokens")"
+    declare count="$(parser_tokens__count "$in_tokens")"
     ((in_index >= count)) && return "$PARSER_INVALID_ARGUMENT_CODE"
 
     declare -i line=0
@@ -1022,14 +1022,14 @@ __parser_check_examples__description_mnemonic_token_values() {
     declare in_tokens="$1"
 
     # shellcheck disable=2155
-    declare -i count="$(__parser_tokens__count "$in_tokens")"
+    declare -i count="$(parser_tokens__count "$in_tokens")"
 
     declare -i index=0
 
     # shellcheck disable=2155
     while ((index < count)); do
-        declare token_type="$(__parser_tokens__type "$in_tokens" "$index")"
-        declare token_value="$(__parser_tokens__value "$in_tokens" "$index")"
+        declare token_type="$(parser_tokens__type "$in_tokens" "$index")"
+        declare token_value="$(parser_tokens__value "$in_tokens" "$index")"
 
         if [[ "$token_type" == CONSTRUCT ]] && [[ "$token_value" =~ ' ' ]]; then
             return "$PARSER_INVALID_TOKENS_CODE"
@@ -1342,17 +1342,17 @@ parser_check_examples__code_allows_alternative_expansion() {
     fi
 
     # shellcheck disable=2155
-    declare -i description_tokens_count="$(__parser_tokens__count "$description_tokens")"
+    declare -i description_tokens_count="$(parser_tokens__count "$description_tokens")"
     # shellcheck disable=2155
-    declare -i code_tokens_count="$(__parser_tokens__count "$code_tokens")"
+    declare -i code_tokens_count="$(parser_tokens__count "$code_tokens")"
 
     declare -i index=0
     declare -i alternative_count=0
     declare description_alternative=
     
     while ((index < description_tokens_count && alternative_count < 1)); do
-        [[ "$(__parser_tokens__type "$description_tokens" "$index")" == CONSTRUCT ]] && {
-            description_alternative="$(__parser_tokens__value "$description_tokens" "$index")"
+        [[ "$(parser_tokens__type "$description_tokens" "$index")" == CONSTRUCT ]] && {
+            description_alternative="$(parser_tokens__value "$description_tokens" "$index")"
             alternative_count+=1
         }
         index+=1
@@ -1360,17 +1360,17 @@ parser_check_examples__code_allows_alternative_expansion() {
 
     ((alternative_count == 1)) || return "$PARSER_NOT_ALLOWED_CODE"
     # shellcheck disable=2155
-    declare -i alternative_piece_count="$(__parser_tokens__count "$(parser_examples__description_alternative_token_pieces "$description_alternative")")"
+    declare -i alternative_piece_count="$(parser_tokens__count "$(parser_examples__description_alternative_token_pieces "$description_alternative")")"
     
     index=0
     declare -i conforming_placeholder_count=0
 
     # shellcheck disable=2155
     while ((index < code_tokens_count && conforming_placeholder_count < 1)); do
-        declare token_type="$(__parser_tokens__type "$code_tokens" "$index")"
-        declare token_value="$(__parser_tokens__value "$code_tokens" "$index")"
+        declare token_type="$(parser_tokens__type "$code_tokens" "$index")"
+        declare token_value="$(parser_tokens__value "$code_tokens" "$index")"
 
-        declare -i token_piece_count="$(__parser_tokens__count "$(parser_examples__code_placeholder_token_pieces "$token_value")")"
+        declare -i token_piece_count="$(parser_tokens__count "$(parser_examples__code_placeholder_token_pieces "$token_value")")"
 
         if [[ "$token_type" == CONSTRUCT ]] && ((token_piece_count == alternative_piece_count)); then
             conforming_placeholder_count+=1

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -15,6 +15,7 @@ declare -i INVALID_EXAMPLE_INDEX_FAIL=20
 declare -i INVALID_CONSTRUCT_FAIL=21
 declare -i INVALID_TOKEN_INDEX_FAIL=22
 declare -i INVALID_TOKEN_VALUE_FAIL=23
+declare -i INVALID_PLACEHOLDER_ALTERNATIVE_FAIL=24
 
 # __parser_check_layout_correctness <page-content>
 # Check whether a specific page content is valid.
@@ -906,4 +907,50 @@ __parser_check_command_example_code_placeholder_alternative_correctness() {
 
     # shellcheck disable=2016
     sed -nE '/^(bool|int|float|char|string|command|option|(\/|\/\?)?file|(\/|\/\?)?directory|(\/|\/\?)?path|(\/|\/\?)?remote-file|(\/|\/\?)?remote-directory|(\/|\/\?)?remote-path|any|remote-any)[*+?]? +[^{}]+$/! Q1' <<<"$in_placeholder_alternative_content"
+}
+
+# parser_output_command_example_code_placeholder_alternative_type <page-content> <placeholder-alternative>
+# Output an alternative type for a specific placeholder alternative.
+#
+# Output:
+#   <alternative-type>
+#
+# Return:
+#   - 0 if placeholder alternative is valid
+#   - 24 otherwise
+#
+# Notes:
+#   - placeholder without trailing \n
+parser_output_command_example_code_placeholder_alternative_type() {
+    declare in_placeholder_alternative_content="$1"
+
+    __parser_check_command_example_code_placeholder_alternative_correctness "$in_placeholder_alternative_content" ||
+        return "$INVALID_PLACEHOLDER_ALTERNATIVE_FAIL"
+
+    sed -E 's/^(\/|\/\?)?([^ *+?]+).+$/\2/' <<<"$in_placeholder_alternative_content"
+}
+
+# parser_output_command_example_code_placeholder_alternative_quantifier <page-content> <placeholder-alternative>
+# Output an quantifier type for a specific placeholder alternative.
+#
+# Output:
+#   <quantifier-type>
+#
+# Return:
+#   - 0 if placeholder alternative is valid
+#   - 24 otherwise
+#
+# Notes:
+#   - placeholder without trailing \n
+parser_output_command_example_code_placeholder_alternative_quantifier() {
+    declare in_placeholder_alternative_content="$1"
+
+    __parser_check_command_example_code_placeholder_alternative_correctness "$in_placeholder_alternative_content" ||
+        return "$INVALID_PLACEHOLDER_ALTERNATIVE_FAIL"
+
+    declare beginning='(\/|\/\?)?[^ *+?]+([*+?]| +([[:digit:]]+\.\.[[:digit:]]+|[[:digit:]]+\.\.|\.\.[[:digit:]]+))'
+    ! sed -nE "/^$beginning/! Q1" <<<"$in_placeholder_alternative_content" && return "$SUCCESS"
+
+    sed -E "s/^$beginning.+$/\2/
+s/^ +//" <<<"$in_placeholder_alternative_content"
 }

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -645,7 +645,7 @@ $(__parser_summary_tag_definition "More information" "$more_information_value")"
 
 
 # __parser_examples__all <content>
-# Output examples from a content.
+# Output examples.
 #
 # Output:
 #   <examples>
@@ -675,10 +675,10 @@ __parser_examples__all() {
 }
 
 # __parser_examples__all_count <content>
-# Output an example count from a content.
+# Output an example count.
 #
 # Output:
-#   <example-count>
+#   <count>
 #
 # Return:
 #   - 0 if <content> is valid
@@ -705,10 +705,10 @@ __parser_examples__all_count() {
 }
 
 # parser_examples__description_at <content> <index>
-# Output an example description from a content.
+# Output an example description.
 #
 # Output:
-#   <example-description>
+#   <description>
 #
 # Return:
 #   - 0 if <content> is valid
@@ -739,7 +739,7 @@ parser_examples__description_at() {
 }
 
 # parser_examples__code_at <content> <index>
-# Output an example code from a content.
+# Output an example code.
 #
 # Output:
 #   <code>
@@ -773,7 +773,7 @@ parser_examples__code_at() {
 }
 
 # __parser_tokens__current <string> <index> <next-token-start>
-# Output the current token from a string.
+# Output the current token.
 #
 # Output:
 #   <current-token>
@@ -805,7 +805,7 @@ __parser_tokens__current() {
 }
 
 # __parser_tokens__all_balanced <string> <special-construct-start-and-end>
-# Output all balanced tokens from a string.
+# Output all balanced tokens.
 #
 # Output:
 #   <balanced-tokens>
@@ -853,7 +853,7 @@ __parser_tokens__all_balanced() {
 }
 
 # __parser_tokens__all_unbalanced <string> <special-construct>
-# Output all unbalanced tokens from a string.
+# Output all unbalanced tokens.
 #
 # Output:
 #   <unbalanced-tokens>
@@ -884,10 +884,10 @@ __parser_tokens__all_unbalanced() {
 }
 
 # __parser_tokens__count <tokens>
-# Output token count from a token list.
+# Output token count.
 #
 # Output:
-#   <token-count>
+#   <count>
 #
 # Return:
 #   - 0 always
@@ -902,7 +902,7 @@ __parser_tokens__count() {
 }
 
 # __parser_tokens__value <tokens> <index>
-# Output a token value from a token list.
+# Output a token value.
 #
 # Output:
 #   <token-value>
@@ -934,7 +934,7 @@ __parser_tokens__value() {
 }
 
 # __parser_tokens__type <tokens> <index>
-# Output a token type from a token list.
+# Output a token type.
 #
 # Output:
 #   <token-type>
@@ -966,7 +966,7 @@ __parser_tokens__type() {
 }
 
 # parser_examples__description_alternative_tokens_at <content> <index>
-# Output alternative and literal tokens from a content.
+# Output alternative and literal tokens.
 #
 # Output:
 #   <alternative-tokens>
@@ -1038,7 +1038,7 @@ __parser_check_examples__description_mnemonic_token_values() {
 }
 
 # parser_examples__description_mnemonic_tokens_at <content> <index>
-# Output mnemonic and literal tokens from a content.
+# Output mnemonic and literal tokens.
 #
 # Output:
 #   <mnemonic-tokens>
@@ -1078,7 +1078,7 @@ parser_examples__description_mnemonic_tokens_at() {
 }
 
 # parser_examples__description_alternative_token_pieces <token>
-# Output pieces from a token.
+# Output alternative pieces.
 #
 # Output:
 #   <tokens>

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -687,3 +687,21 @@ __parser_output_tokenized_by_unbalanced_tokens() {
         index+=1
     done
 }
+
+# __parser_output_token_count <tokens>
+# Output token count from a token list.
+#
+# Output:
+#   <token-count>
+#
+# Return:
+#   - 0 always
+__parser_output_token_count() {
+    declare tokens="$1"
+
+    # shellcheck disable=2155
+    declare -i count="$(echo -n "$tokens" | wc -l)"
+    ((count % 2 == 0)) || count+=1
+
+    echo -n "$((count / 2))"
+}

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -887,3 +887,23 @@ parser_output_command_example_code_tokens() {
 
     echo -n "$tokens"
 }
+
+# __parser_check_command_example_code_placeholder_alternative_correctness <placeholder-alternative>
+# Check whether a specific placeholder alternative is valid.
+#
+# Output:
+#   <empty-string>
+#
+# Return:
+#   - 0 if placeholder alternative is valid
+#   - 1 otherwise
+#
+# Notes:
+#   - placeholder without trailing \n
+#   - escaping is not checked
+__parser_check_command_example_code_placeholder_alternative_correctness() {
+    declare in_placeholder_alternative_content="$1"
+
+    # shellcheck disable=2016
+    sed -nE '/^(bool|int|float|char|string|command|option|(\/|\/\?)?file|(\/|\/\?)?directory|(\/|\/\?)?path|(\/|\/\?)?remote-file|(\/|\/\?)?remote-directory|(\/|\/\?)?remote-path|any|remote-any)[*+?]? +[^{}]+$/! Q1' <<<"$in_placeholder_alternative_content"
+}

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -748,7 +748,7 @@ __parser_output_token_type() {
 }
 
 # parser_output_command_example_description_tokens <page-content> <example-index>
-# Output an example description tokens for alternatives and literals from a specific page content.
+# Output description tokens for alternatives and literals from a specific page content.
 #
 # Output:
 #   <description-tokens>
@@ -783,7 +783,7 @@ parser_output_command_example_description_tokens() {
 }
 
 # parser_output_command_example_description_mnemonic_tokens <page-content> <example-index>
-# Output an example description tokens for mnemonics and literals from a specific page content.
+# Output description tokens for mnemonics and literals from a specific page content.
 #
 # Output:
 #   <description-tokens>

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -579,7 +579,6 @@ parser_summary_structure_compatible_value() {
     echo -n "$(__parser_string_unify "$(__parser_summary_tag_value "$in_content" "Structure compatible")")"
 }
 
-
 # __parser_summary_tag_definition <tag> <tag-value>
 # Output a tag definition.
 #

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -927,7 +927,7 @@ parser_output_command_example_code_placeholder_alternative_type() {
     __parser_check_command_example_code_placeholder_alternative_correctness "$in_placeholder_alternative_content" ||
         return "$INVALID_PLACEHOLDER_ALTERNATIVE_FAIL"
 
-    sed -E 's/^(\/|\/\?)?([^ *+?]+).+$/\2/' <<<"$in_placeholder_alternative_content"
+    sed -E 's/^((\/|\/\?)?[^ *+?]+).+$/\1/' <<<"$in_placeholder_alternative_content"
 }
 
 # parser_output_command_example_code_placeholder_alternative_quantifier <page-content> <placeholder-alternative>

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -120,7 +120,7 @@ parser_output_command_description() {
     declare command_summary="$(sed -nE '/^>/ p' <<<"$page_content")"
     __parser_check_command_summary_correctness "$command_summary" || return "$INVALID_SUMMARY_FAIL"
 
-    sed -nE '/^> [^:]+$/ { s/^> +//; s/ +$//; p; }' <<<"$command_summary"
+    sed -nE '/^> [^:]+$/ { s/^> +//; s/ +$//; s/  +/ /g; p; }' <<<"$command_summary"
 }
 
 # __parser_check_command_tag_correctness <command-tag>
@@ -156,7 +156,7 @@ __parser_check_command_tag_value_correctness() {
     elif [[ "$command_tag" =~ ^(See also|Aliases|Syntax compatible|Structure compatible)$ ]]; then
         ! [[ "$command_tag_value" =~ ,, ]]
     else
-        [[ "$command_tag" == "More information" ]]
+        [[ "$command_tag" =~ ^(More information|Help|Version)$ ]]
     fi
 }
 
@@ -268,7 +268,7 @@ parser_output_command_more_information_tag_value() {
 parser_output_command_internal_tag_value() {
     declare page_content="$1"
 
-    parser_output_command_tag_value "$page_content" "Internal"
+    __parser_output_command_tag_value "$page_content" "Internal"
 }
 
 # parser_output_command_internal_tag_or_default <page-content>
@@ -310,7 +310,7 @@ parser_output_command_internal_tag_value_or_default() {
 parser_output_command_deprecated_tag_value() {
     declare page_content="$1"
 
-    parser_output_command_tag_value "$page_content" "Deprecated"
+    __parser_output_command_tag_value "$page_content" "Deprecated"
 }
 
 # parser_output_command_deprecated_tag_or_default <page-content>
@@ -352,7 +352,7 @@ parser_output_command_deprecated_tag_value_or_default() {
 parser_output_command_see_also_tag_value() {
     declare page_content="$1"
 
-    parser_output_command_tag_value "$page_content" "See also"
+    __parser_output_command_tag_value "$page_content" "See also"
 }
 
 # parser_output_command_aliases_tag <page-content>
@@ -370,7 +370,7 @@ parser_output_command_see_also_tag_value() {
 parser_output_command_aliases_tag_value() {
     declare page_content="$1"
 
-    parser_output_command_tag_value "$page_content" "Aliases"
+    __parser_output_command_tag_value "$page_content" "Aliases"
 }
 
 # parser_output_command_syntax_compatible_tag <page-content>
@@ -385,10 +385,10 @@ parser_output_command_aliases_tag_value() {
 #
 # Notes:
 #   - .clip page content without trailing \n
-parser_output_command_syntax_compatible_tag() {
+parser_output_command_syntax_compatible_tag_value() {
     declare page_content="$1"
 
-    parser_output_command_tag_value "$page_content" "Syntax compatible"
+    __parser_output_command_tag_value "$page_content" "Syntax compatible"
 }
 
 # parser_output_command_help_tag <page-content>
@@ -406,7 +406,7 @@ parser_output_command_syntax_compatible_tag() {
 parser_output_command_help_tag_value() {
     declare page_content="$1"
 
-    parser_output_command_tag_value "$page_content" "Help"
+    __parser_output_command_tag_value "$page_content" "Help"
 }
 
 # parser_output_command_version_tag <page-content>
@@ -424,7 +424,7 @@ parser_output_command_help_tag_value() {
 parser_output_command_version_tag_value() {
     declare page_content="$1"
 
-    parser_output_command_tag_value "$page_content" "Version"
+    __parser_output_command_tag_value "$page_content" "Version"
 }
 
 # parser_output_command_structure_compatible_tag <page-content>
@@ -442,5 +442,13 @@ parser_output_command_version_tag_value() {
 parser_output_command_structure_compatible_tag_value() {
     declare page_content="$1"
 
-    parser_output_command_tag_value "$page_content" "Structure compatible"
+    __parser_output_command_tag_value "$page_content" "Structure compatible"
 }
+parser_output_command_description '# some
+
+> Some  text.
+> More information: https://example.com.
+
+- Some text:
+
+`some`'

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -705,3 +705,29 @@ __parser_output_token_count() {
 
     echo -n "$((count / 2))"
 }
+
+# __parser_output_token_value <tokens> <index>
+# Output token value from a token list.
+#
+# Output:
+#   <token-value>
+#
+# Return:
+#   - 0 always
+__parser_output_token_value() {
+    declare tokens="$1"
+    declare index="$2"
+
+    declare count="$(__parser_output_token_count "$tokens")"
+    declare -i line=0
+    declare -i current_index=0
+
+    mapfile -t tokens <<<"$tokens"
+
+    while ((line < count * 2)) && ((current_index != index)); do
+        line+=2
+        current_index+=1
+    done
+
+    [[ -n "${tokens[line + 1]}" ]] && echo -n "${tokens[line + 1]}"
+}

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -11,6 +11,14 @@ declare -i PARSER_NOT_ALLOWED_CODE=6
 
 
 
+# parser__version
+# Output a parser version.
+#
+# Output:
+#   <version>
+#
+# Return:
+#   - 0 always
 parser__version() {
     echo "1.0.0"
 }

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -578,9 +578,7 @@ parser_summary_cleaned_up() {
     declare in_content="$1"
 
     if [[ -n "$CHECK" ]] && ((CHECK == 0)); then
-        __parser_check_content "$in_content" || return "$PARSER_INVALID_CONTENT_CODE"
-        __parser_check_summary "$in_content" || return "$PARSER_INVALID_CONTENT_CODE"
-        __parser_summary_tags "$in_content" || return "$PARSER_INVALID_CONTENT_CODE"
+        __parser_summary_tags "$in_content" > /dev/null || return "$PARSER_INVALID_SUMMARY_CODE"
     fi
 
     CHECK= # as we already checked input there is no need to do it in each data request

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -627,34 +627,34 @@ parser_summary_cleaned_up() {
     # shellcheck disable=2155
     declare description="$(parser_summary_description "$in_content")"
     # shellcheck disable=2155
-    declare more_information="$(parser_summary_more_information_value "$in_content")"
+    declare more_information_value="$(parser_summary_more_information_value "$in_content")"
     # shellcheck disable=2155
-    declare internal="$(parser_summary_internal_value_or_default "$in_content")"
+    declare internal_value="$(parser_summary_internal_value_or_default "$in_content")"
     # shellcheck disable=2155
-    declare deprecated="$(parser_summary_deprecated_value_or_default "$in_content")"
+    declare deprecated_value="$(parser_summary_deprecated_value_or_default "$in_content")"
     # shellcheck disable=2155
-    declare see_also="$(parser_summary_see_also_value "$in_content")"
+    declare see_also_value="$(parser_summary_see_also_value "$in_content")"
     # shellcheck disable=2155
-    declare aliases="$(parser_summary_aliases_value "$in_content")"
+    declare aliases_value="$(parser_summary_aliases_value "$in_content")"
     # shellcheck disable=2155
-    declare syntax_compatible="$(parser_summary_syntax_compatible_value "$in_content")"
+    declare syntax_compatible_value="$(parser_summary_syntax_compatible_value "$in_content")"
     # shellcheck disable=2155
-    declare help="$(parser_summary_help_value "$in_content")"
+    declare help_value="$(parser_summary_help_value "$in_content")"
     # shellcheck disable=2155
-    declare version="$(parser_summary_version_value "$in_content")"
+    declare version_value="$(parser_summary_version_value "$in_content")"
     # shellcheck disable=2155
-    declare structure_compatible="$(parser_summary_structure_compatible_value "$in_content")"
+    declare structure_compatible_value="$(parser_summary_structure_compatible_value "$in_content")"
     
     echo -n "> $description
-$(__parser_summary_tag_definition "Internal" "$internal")
-$(__parser_summary_tag_definition "Deprecated" "$deprecated")
-$(__parser_summary_tag_definition "Help" "$help")
-$(__parser_summary_tag_definition "Version" "$version")
-$(__parser_summary_tag_definition "Syntax compatible" "$syntax_compatible")
-$(__parser_summary_tag_definition "Structure compatible" "$structure_compatible")
-$(__parser_summary_tag_definition "Aliases" "$aliases")
-$(__parser_summary_tag_definition "See also" "$see_also")
-$(__parser_summary_tag_definition "More information" "$more_information")" |
+$(__parser_summary_tag_definition "Internal" "$internal_value")
+$(__parser_summary_tag_definition "Deprecated" "$deprecated_value")
+$(__parser_summary_tag_definition "Help" "$help_value")
+$(__parser_summary_tag_definition "Version" "$version_value")
+$(__parser_summary_tag_definition "Syntax compatible" "$syntax_compatible_value")
+$(__parser_summary_tag_definition "Structure compatible" "$structure_compatible_value")
+$(__parser_summary_tag_definition "Aliases" "$aliases_value")
+$(__parser_summary_tag_definition "See also" "$see_also_value")
+$(__parser_summary_tag_definition "More information" "$more_information_value")" |
     sed -nE '/./ p'
 }
 

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -11,7 +11,7 @@ declare -i PARSER_NOT_ALLOWED_CODE=6
 
 
 
-# __parser_string_join <separator> <strings>
+# __parser_string__join <separator> <strings>
 # Output joined strings.
 #
 # Output:
@@ -22,7 +22,7 @@ declare -i PARSER_NOT_ALLOWED_CODE=6
 #
 # Notes:
 #   - <string> should not contain trailing \n
-__parser_string_join() {
+__parser_string__join() {
   declare in_separator="$1"
   declare in_string="$2"
 
@@ -31,7 +31,7 @@ __parser_string_join() {
   fi
 }
 
-# __parser_string_unify <string>
+# __parser_string__unify <string>
 # Output string without repeated comma-separated items.
 #
 # Output:
@@ -42,18 +42,18 @@ __parser_string_join() {
 #
 # Notes:
 #   - <string> should not contain trailing \n
-__parser_string_unify() {
+__parser_string__unify() {
     declare string="$1"
 
     mapfile -t string_array < <(echo -n "$string" | sed -E 's/ +/ /g
     s/ *, */\n/g' | sort -r -u)
 
-    __parser_string_join ", " "${string_array[@]}"
+    __parser_string__join ", " "${string_array[@]}"
 }
 
 
 
-# __parser_check_content <content>
+# __parser_check__content <content>
 # Check whether a content is valid.
 #
 # Output:
@@ -65,7 +65,7 @@ __parser_string_unify() {
 #
 # Notes:
 #   - <content> should not contain trailing \n
-__parser_check_content() {
+__parser_check__content() {
     declare in_content="$1"
 
     # shellcheck disable=2016
@@ -76,8 +76,8 @@ __parser_check_content() {
         return "$PARSER_INVALID_CONTENT_CODE"
 }
 
-# parser_header <content>
-# Output a header from a content.
+# parser__header <content>
+# Output a header.
 #
 # Output:
 #   <header>
@@ -89,11 +89,11 @@ __parser_check_content() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-parser_header() {
+parser__header() {
     declare in_content="$1"
 
     if [[ -n "$CHECK" ]] && ((CHECK == 0)); then
-        __parser_check_content "$in_content" || return "$PARSER_INVALID_CONTENT_CODE"
+        __parser_check__content "$in_content" || return "$PARSER_INVALID_CONTENT_CODE"
     fi
 
     sed -nE '1 {
@@ -106,7 +106,7 @@ parser_header() {
 
 
 
-# __parser_check_summary <summary>
+# __parser_check__summary <summary>
 # Check whether a summary is valid.
 #
 # Output:
@@ -118,7 +118,7 @@ parser_header() {
 #
 # Notes:
 #   - <summary> should not contain trailing \n
-__parser_check_summary() {
+__parser_check__summary() {
     declare in_summary="$1"
 
     # shellcheck disable=2016
@@ -129,7 +129,7 @@ __parser_check_summary() {
         return "$PARSER_INVALID_SUMMARY_CODE"
 }
 
-# parser_summary_description <content>
+# parser_summary__description <content>
 # Output a description from a summary.
 #
 # Output:
@@ -143,17 +143,17 @@ __parser_check_summary() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-parser_summary_description() {
+parser_summary__description() {
     declare in_content="$1"
 
     if [[ -n "$CHECK" ]] && ((CHECK == 0)); then
-        __parser_check_content "$in_content" || return "$?"
+        __parser_check__content "$in_content" || return "$?"
     fi
     
     # shellcheck disable=2155
     declare summary="$(sed -nE '/^>/ p' <<<"$in_content")"
     if [[ -n "$CHECK" ]] && ((CHECK == 0)); then
-        __parser_check_summary "$summary" || return "$?"
+        __parser_check__summary "$summary" || return "$?"
     fi
 
     sed -nE '/^> [^:]+$/ {
@@ -165,7 +165,7 @@ parser_summary_description() {
     }' <<<"$summary"
 }
 
-# __parser_check_summary_tag <tag>
+# __parser_check_summary__tag <tag>
 # Check whether a tag is valid.
 #
 # Output:
@@ -177,7 +177,7 @@ parser_summary_description() {
 #
 # Notes:
 #   - <tag> should not contain trailing \n
-__parser_check_summary_tag() {
+__parser_check_summary__tag() {
     declare in_tag="$1"
 
     [[ "$in_tag" =~ ^(More information|Internal|Deprecated|See also|Aliases\
@@ -185,7 +185,7 @@ __parser_check_summary_tag() {
         return "$PARSER_INVALID_SUMMARY_CODE"
 }
 
-# __parser_check_summary_tag_value <tag> <tag-value>
+# __parser_check_summary__tag_value <tag> <tag-value>
 # Check whether a tag value is valid.
 #
 # Output:
@@ -197,7 +197,7 @@ __parser_check_summary_tag() {
 #
 # Notes:
 #   - <tag> and <tag-value> should not contain trailing \n
-__parser_check_summary_tag_value() {
+__parser_check_summary__tag_value() {
     declare in_tag="$1"
     declare in_tag_value="$2"
 
@@ -208,7 +208,7 @@ __parser_check_summary_tag_value() {
     fi
 }
 
-# __parser_check_summary_tags_values <tags>
+# __parser_check_summary__tags_values <tags>
 # Check whether tag values are valid.
 #
 # Output:
@@ -220,7 +220,7 @@ __parser_check_summary_tag_value() {
 #
 # Notes:
 #   - <tag> and <tag-value> should not contain trailing \n
-__parser_check_summary_tags_values() {
+__parser_check_summary__tags_values() {
     declare in_tags="$1"
 
     mapfile -t tags_array <<<"$in_tags"
@@ -231,14 +231,14 @@ __parser_check_summary_tags_values() {
         declare tag_value="${tags_array[index + 1]}"
         
         if [[ -n "$CHECK" ]] && ((CHECK == 0)); then
-            __parser_check_summary_tag "$tag" || return "$?"
-            __parser_check_summary_tag_value "$tag" "$tag_value" || return "$?"
+            __parser_check_summary__tag "$tag" || return "$?"
+            __parser_check_summary__tag_value "$tag" "$tag_value" || return "$?"
         fi
         index+=2
     done
 }
 
-# __parser_summary_tags <content>
+# __parser_summary__tags <content>
 # Output all tags from a summary.
 #
 # Output:
@@ -252,17 +252,17 @@ __parser_check_summary_tags_values() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-__parser_summary_tags() {
+__parser_summary__tags() {
     declare in_content="$1"
 
     if [[ -n "$CHECK" ]] && ((CHECK == 0)); then
-        __parser_check_content "$in_content" || return "$?"
+        __parser_check__content "$in_content" || return "$?"
     fi
     
     # shellcheck disable=2155
     declare summary="$(sed -nE '/^>/ p' <<<"$in_content")"
     if [[ -n "$CHECK" ]] && ((CHECK == 0)); then
-        __parser_check_summary "$summary" || return "$?"
+        __parser_check__summary "$summary" || return "$?"
     fi
 
     # shellcheck disable=2155
@@ -277,13 +277,13 @@ __parser_summary_tags() {
     }' <<<"$summary")"
 
     if [[ -n "$CHECK" ]] && ((CHECK == 0)); then
-        __parser_check_summary_tags_values "$tags" || return "$?"
+        __parser_check_summary__tags_values "$tags" || return "$?"
     fi
 
     echo -n "$tags"
 }
 
-# __parser_summary_tag_value <content> <tag>
+# __parser_summary__tag_value <content> <tag>
 # Output a tag value from a summary.
 #
 # Output:
@@ -297,7 +297,7 @@ __parser_summary_tags() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-__parser_summary_tag_value() {
+__parser_summary__tag_value() {
     declare in_content="$1"
     # shellcheck disable=2155
     declare in_tag="$(sed -E 's/^ +//
@@ -305,11 +305,11 @@ __parser_summary_tag_value() {
         s/ +/ /g' <<<"$2")"
 
     if [[ -n "$CHECK" ]] && ((CHECK == 0)); then
-        __parser_check_summary_tag "$in_tag" || return "$?"
+        __parser_check_summary__tag "$in_tag" || return "$?"
     fi
 
     declare tags=
-    tags="$(__parser_summary_tags "$in_content")"
+    tags="$(__parser_summary__tags "$in_content")"
     declare -i status=$?
     if [[ -n "$CHECK" ]] && ((CHECK == 0)); then
         ((status == 0)) || return "$?"
@@ -331,7 +331,7 @@ __parser_summary_tag_value() {
     done
 }
 
-# parser_summary_more_information_value <content>
+# parser_summary__more_information_value <content>
 # Output "More information" tag value from a content.
 #
 # Output:
@@ -345,13 +345,13 @@ __parser_summary_tag_value() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-parser_summary_more_information_value() {
+parser_summary__more_information_value() {
     declare in_content="$1"
 
-    __parser_summary_tag_value "$in_content" "More information"
+    __parser_summary__tag_value "$in_content" "More information"
 }
 
-# parser_summary_internal_value <content>
+# parser_summary__internal_value <content>
 # Output "Internal" tag value from a content.
 #
 # Output:
@@ -365,13 +365,13 @@ parser_summary_more_information_value() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-parser_summary_internal_value() {
+parser_summary__internal_value() {
     declare in_content="$1"
 
-    __parser_summary_tag_value "$in_content" "Internal"
+    __parser_summary__tag_value "$in_content" "Internal"
 }
 
-# parser_summary_internal_value_or_default <content>
+# parser_summary__internal_value_or_default <content>
 # Output "Internal" tag value from a content or default.
 #
 # Output:
@@ -385,11 +385,11 @@ parser_summary_internal_value() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-parser_summary_internal_value_or_default() {
+parser_summary__internal_value_or_default() {
     declare in_content="$1"
 
     declare tag_value=
-    tag_value="$(parser_summary_internal_value "$in_content")"
+    tag_value="$(parser_summary__internal_value "$in_content")"
     # shellcheck disable=2181
     (($? == 0)) || return "$?"
 
@@ -397,7 +397,7 @@ parser_summary_internal_value_or_default() {
     echo -n "$tag_value"
 }
 
-# parser_summary_deprecated_value <content>
+# parser_summary__deprecated_value <content>
 # Output "Deprecated" tag value from a content.
 #
 # Output:
@@ -411,13 +411,13 @@ parser_summary_internal_value_or_default() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-parser_summary_deprecated_value() {
+parser_summary__deprecated_value() {
     declare in_content="$1"
 
-    __parser_summary_tag_value "$in_content" "Deprecated"
+    __parser_summary__tag_value "$in_content" "Deprecated"
 }
 
-# parser_summary_deprecated_value_or_default <content>
+# parser_summary__deprecated_value_or_default <content>
 # Output "Deprecated" tag value from a content or default.
 #
 # Output:
@@ -431,11 +431,11 @@ parser_summary_deprecated_value() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-parser_summary_deprecated_value_or_default() {
+parser_summary__deprecated_value_or_default() {
     declare in_content="$1"
 
     declare output=
-    output="$(parser_summary_deprecated_value "$in_content")"
+    output="$(parser_summary__deprecated_value "$in_content")"
     # shellcheck disable=2181
     (($? == 0)) || return "$?"
 
@@ -443,7 +443,7 @@ parser_summary_deprecated_value_or_default() {
     echo -n "$output"
 }
 
-# parser_summary_see_also_value <content>
+# parser_summary__see_also_value <content>
 # Output "See also" tag value from a content.
 #
 # Output:
@@ -457,13 +457,13 @@ parser_summary_deprecated_value_or_default() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-parser_summary_see_also_value() {
+parser_summary__see_also_value() {
     declare in_content="$1"
 
-    echo -n "$(__parser_string_unify "$(__parser_summary_tag_value "$in_content" "See also")")"
+    echo -n "$(__parser_string__unify "$(__parser_summary__tag_value "$in_content" "See also")")"
 }
 
-# parser_summary_aliases_value <content>
+# parser_summary__aliases_value <content>
 # Output "Aliases" tag value from a content.
 #
 # Output:
@@ -477,13 +477,13 @@ parser_summary_see_also_value() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-parser_summary_aliases_value() {
+parser_summary__aliases_value() {
     declare in_content="$1"
 
-    echo -n "$(__parser_string_unify "$(__parser_summary_tag_value "$in_content" "Aliases")")"
+    echo -n "$(__parser_string__unify "$(__parser_summary__tag_value "$in_content" "Aliases")")"
 }
 
-# parser_summary_syntax_compatible_value <content>
+# parser_summary__syntax_compatible_value <content>
 # Output "Syntax compatible" tag value from a content.
 #
 # Output:
@@ -497,13 +497,13 @@ parser_summary_aliases_value() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-parser_summary_syntax_compatible_value() {
+parser_summary__syntax_compatible_value() {
     declare in_content="$1"
 
-    echo -n "$(__parser_string_unify "$(__parser_summary_tag_value "$in_content" "Syntax compatible")")"
+    echo -n "$(__parser_string__unify "$(__parser_summary__tag_value "$in_content" "Syntax compatible")")"
 }
 
-# parser_summary_help_value <content>
+# parser_summary__help_value <content>
 # Output "Help" tag value from a content.
 #
 # Output:
@@ -517,13 +517,13 @@ parser_summary_syntax_compatible_value() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-parser_summary_help_value() {
+parser_summary__help_value() {
     declare in_content="$1"
 
-    echo -n "$(__parser_string_unify "$(__parser_summary_tag_value "$in_content" "Help")")"
+    echo -n "$(__parser_string__unify "$(__parser_summary__tag_value "$in_content" "Help")")"
 }
 
-# parser_summary_version_value <content>
+# parser_summary__version_value <content>
 # Output "Version" tag value from a content.
 #
 # Output:
@@ -537,13 +537,13 @@ parser_summary_help_value() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-parser_summary_version_value() {
+parser_summary__version_value() {
     declare in_content="$1"
 
-    echo -n "$(__parser_string_unify "$(__parser_summary_tag_value "$in_content" "Version")")"
+    echo -n "$(__parser_string__unify "$(__parser_summary__tag_value "$in_content" "Version")")"
 }
 
-# parser_summary_structure_compatible_value <content>
+# parser_summary__structure_compatible_value <content>
 # Output "Structure compatible" tag value from a content.
 #
 # Output:
@@ -557,13 +557,13 @@ parser_summary_version_value() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-parser_summary_structure_compatible_value() {
-    declare in_page_content="$1"
+parser_summary__structure_compatible_value() {
+    declare in_content="$1"
 
-    echo -n "$(__parser_string_unify "$(__parser_summary_tag_value "$in_content" "Structure compatible")")"
+    echo -n "$(__parser_string__unify "$(__parser_summary__tag_value "$in_content" "Structure compatible")")"
 }
 
-# __parser_summary_tag_definition <tag> <tag-value>
+# __parser_summary__tag_definition <tag> <tag-value>
 # Output a tag definition.
 #
 # Output:
@@ -574,7 +574,7 @@ parser_summary_structure_compatible_value() {
 #
 # Notes:
 #   - <tag> and <tag-value> should not contain trailing \n
-__parser_summary_tag_definition() {
+__parser_summary__tag_definition() {
     declare in_tag="$1"
     declare in_tag_value="$2"
 
@@ -585,7 +585,7 @@ __parser_summary_tag_definition() {
     echo -n "> $in_tag: $in_tag_value"
 }
 
-# parser_summary_cleaned_up <content>
+# parser_summary__cleaned_up <content>
 # Output summary with sorted tags and applied spacing and punctuation fixes.
 #
 # Output:
@@ -599,46 +599,46 @@ __parser_summary_tag_definition() {
 # Notes:
 #   - <content> should not contain trailing \n
 #   - checks are performed just when $CHECK environment variable is not empty and is zero
-parser_summary_cleaned_up() {
+parser_summary__cleaned_up() {
     declare in_content="$1"
 
     if [[ -n "$CHECK" ]] && ((CHECK == 0)); then
-        __parser_summary_tags "$in_content" > /dev/null || return "$PARSER_INVALID_SUMMARY_CODE"
+        __parser_summary__tags "$in_content" > /dev/null || return "$PARSER_INVALID_SUMMARY_CODE"
     fi
 
     CHECK= # as we already checked input there is no need to do it in each data request
 
     # shellcheck disable=2155
-    declare description="$(parser_summary_description "$in_content")"
+    declare description="$(parser_summary__description "$in_content")"
     # shellcheck disable=2155
-    declare more_information_value="$(parser_summary_more_information_value "$in_content")"
+    declare more_information_value="$(parser_summary__more_information_value "$in_content")"
     # shellcheck disable=2155
-    declare internal_value="$(parser_summary_internal_value_or_default "$in_content")"
+    declare internal_value="$(parser_summary__internal_value_or_default "$in_content")"
     # shellcheck disable=2155
-    declare deprecated_value="$(parser_summary_deprecated_value_or_default "$in_content")"
+    declare deprecated_value="$(parser_summary__deprecated_value_or_default "$in_content")"
     # shellcheck disable=2155
-    declare see_also_value="$(parser_summary_see_also_value "$in_content")"
+    declare see_also_value="$(parser_summary__see_also_value "$in_content")"
     # shellcheck disable=2155
-    declare aliases_value="$(parser_summary_aliases_value "$in_content")"
+    declare aliases_value="$(parser_summary__aliases_value "$in_content")"
     # shellcheck disable=2155
-    declare syntax_compatible_value="$(parser_summary_syntax_compatible_value "$in_content")"
+    declare syntax_compatible_value="$(parser_summary__syntax_compatible_value "$in_content")"
     # shellcheck disable=2155
-    declare help_value="$(parser_summary_help_value "$in_content")"
+    declare help_value="$(parser_summary__help_value "$in_content")"
     # shellcheck disable=2155
-    declare version_value="$(parser_summary_version_value "$in_content")"
+    declare version_value="$(parser_summary__version_value "$in_content")"
     # shellcheck disable=2155
-    declare structure_compatible_value="$(parser_summary_structure_compatible_value "$in_content")"
+    declare structure_compatible_value="$(parser_summary__structure_compatible_value "$in_content")"
     
     echo -n "> $description
-$(__parser_summary_tag_definition "Internal" "$internal_value")
-$(__parser_summary_tag_definition "Deprecated" "$deprecated_value")
-$(__parser_summary_tag_definition "Help" "$help_value")
-$(__parser_summary_tag_definition "Version" "$version_value")
-$(__parser_summary_tag_definition "Syntax compatible" "$syntax_compatible_value")
-$(__parser_summary_tag_definition "Structure compatible" "$structure_compatible_value")
-$(__parser_summary_tag_definition "Aliases" "$aliases_value")
-$(__parser_summary_tag_definition "See also" "$see_also_value")
-$(__parser_summary_tag_definition "More information" "$more_information_value")" |
+$(__parser_summary__tag_definition "Internal" "$internal_value")
+$(__parser_summary__tag_definition "Deprecated" "$deprecated_value")
+$(__parser_summary__tag_definition "Help" "$help_value")
+$(__parser_summary__tag_definition "Version" "$version_value")
+$(__parser_summary__tag_definition "Syntax compatible" "$syntax_compatible_value")
+$(__parser_summary__tag_definition "Structure compatible" "$structure_compatible_value")
+$(__parser_summary__tag_definition "Aliases" "$aliases_value")
+$(__parser_summary__tag_definition "See also" "$see_also_value")
+$(__parser_summary__tag_definition "More information" "$more_information_value")" |
     sed -nE '/./ p'
 }
 
@@ -661,7 +661,7 @@ __parser_examples__all() {
     declare in_content="$1"
 
     if [[ -n "$CHECK" ]] && ((CHECK == 0)); then
-        __parser_check_content "$in_content" || return "$?"
+        __parser_check__content "$in_content" || return "$?"
     fi
     
     # shellcheck disable=2016
@@ -1285,7 +1285,7 @@ parser_examples__code_placeholder_piece_examples() {
     # shellcheck disable=2155
     declare description="$(__parser_tokens__current "$in_piece" 0 ":")"
     declare -i description_length="${#description} + 1"
-    echo -n "$(sed -E 's/^ +//' <<< "${in_placeholder_piece:description_length}")"
+    echo -n "$(sed -E 's/^ +//' <<< "${in_piece:description_length}")"
 }
 
 

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -560,6 +560,46 @@ __parser_summary_tag_definition() {
     echo -n "> $in_tag: $in_tag_value"
 }
 
+# __parser_string_join <separator> <strings>
+# Output joined strings.
+#
+# Output:
+#   <strings>
+#
+# Return:
+#   - 0 always
+#
+# Notes:
+#   - <string> should not contain trailing \n
+__parser_string_join() {
+  declare in_separator="$1"
+  declare in_string="$2"
+
+  if shift 2; then
+    printf '%s' "$in_string" "${@/#/$in_separator}"
+  fi
+}
+
+# __parser_string_unify <string>
+# Output string without repeated comma-separated items.
+#
+# Output:
+#   <string>
+#
+# Return:
+#   - 0 always
+#
+# Notes:
+#   - <string> should not contain trailing \n
+__parser_string_unify() {
+    declare string="$1"
+
+    mapfile -t string_array < <(echo -n "$string" | sed -E 's/ +/ /g
+    s/ *, */\n/g' | sort -r -u)
+
+    __parser_string_join ", " "${string_array[@]}"
+}
+
 # parser_summary_cleaned_up <content>
 # Output summary with sorted tags and applied spacing and punctuation fixes.
 #
@@ -592,17 +632,17 @@ parser_summary_cleaned_up() {
     # shellcheck disable=2155
     declare deprecated="$(parser_summary_deprecated_value_or_default "$in_content")"
     # shellcheck disable=2155
-    declare see_also="$(parser_summary_see_also_value "$in_content")"
+    declare see_also="$(__parser_string_unify "$(parser_summary_see_also_value "$in_content")")"
     # shellcheck disable=2155
-    declare aliases="$(parser_summary_aliases_value "$in_content")"
+    declare aliases="$(__parser_string_unify "$(parser_summary_aliases_value "$in_content")")"
     # shellcheck disable=2155
-    declare syntax_compatible="$(parser_summary_syntax_compatible_value "$in_content")"
+    declare syntax_compatible="$(__parser_string_unify "$(parser_summary_syntax_compatible_value "$in_content")")"
     # shellcheck disable=2155
-    declare help="$(parser_summary_help_value "$in_content")"
+    declare help="$(__parser_string_unify "$(parser_summary_help_value "$in_content")")"
     # shellcheck disable=2155
-    declare version="$(parser_summary_version_value "$in_content")"
+    declare version="$(__parser_string_unify "$(parser_summary_version_value "$in_content")")"
     # shellcheck disable=2155
-    declare structure_compatible="$(parser_summary_structure_compatible_value "$in_content")"
+    declare structure_compatible="$(__parser_string_unify "$(parser_summary_structure_compatible_value "$in_content")")"
     
     echo -n "> $description
 $(__parser_summary_tag_definition "Internal" "$internal")

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -519,7 +519,7 @@ __parser_output_command_example_count() {
 
     # shellcheck disable=2155
     declare -i count="$(echo "$examples" | wc -l)"
-    ((count % 2 == 0)) || ((count++))
+    ((count % 2 == 0)) || count+=1
 
     echo -n "$((count / 2))"
 }

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -27,6 +27,48 @@ declare -i PARSER_INVALID_TOKENS_CODE=4
 
 
 
+# __parser_string_join <separator> <strings>
+# Output joined strings.
+#
+# Output:
+#   <strings>
+#
+# Return:
+#   - 0 always
+#
+# Notes:
+#   - <string> should not contain trailing \n
+__parser_string_join() {
+  declare in_separator="$1"
+  declare in_string="$2"
+
+  if shift 2; then
+    printf '%s' "$in_string" "${@/#/$in_separator}"
+  fi
+}
+
+# __parser_string_unify <string>
+# Output string without repeated comma-separated items.
+#
+# Output:
+#   <string>
+#
+# Return:
+#   - 0 always
+#
+# Notes:
+#   - <string> should not contain trailing \n
+__parser_string_unify() {
+    declare string="$1"
+
+    mapfile -t string_array < <(echo -n "$string" | sed -E 's/ +/ /g
+    s/ *, */\n/g' | sort -r -u)
+
+    __parser_string_join ", " "${string_array[@]}"
+}
+
+
+
 # __parser_check_content <content>
 # Check whether a content is valid.
 #
@@ -434,7 +476,7 @@ parser_summary_deprecated_value_or_default() {
 parser_summary_see_also_value() {
     declare in_content="$1"
 
-    __parser_summary_tag_value "$in_content" "See also"
+    echo -n "$(__parser_string_unify "$(__parser_summary_tag_value "$in_content" "See also")")"
 }
 
 # parser_summary_aliases_value <content>
@@ -454,7 +496,7 @@ parser_summary_see_also_value() {
 parser_summary_aliases_value() {
     declare in_content="$1"
 
-    __parser_summary_tag_value "$in_content" "Aliases"
+    echo -n "$(__parser_string_unify "$(__parser_summary_tag_value "$in_content" "Aliases")")"
 }
 
 # parser_summary_syntax_compatible_value <content>
@@ -474,7 +516,7 @@ parser_summary_aliases_value() {
 parser_summary_syntax_compatible_value() {
     declare in_content="$1"
 
-    __parser_summary_tag_value "$in_content" "Syntax compatible"
+    echo -n "$(__parser_string_unify "$(__parser_summary_tag_value "$in_content" "Syntax compatible")")"
 }
 
 # parser_summary_help_value <content>
@@ -494,7 +536,7 @@ parser_summary_syntax_compatible_value() {
 parser_summary_help_value() {
     declare in_content="$1"
 
-    __parser_summary_tag_value "$in_content" "Help"
+    echo -n "$(__parser_string_unify "$(__parser_summary_tag_value "$in_content" "Help")")"
 }
 
 # parser_summary_version_value <content>
@@ -514,7 +556,7 @@ parser_summary_help_value() {
 parser_summary_version_value() {
     declare in_content="$1"
 
-    __parser_summary_tag_value "$in_content" "Version"
+    echo -n "$(__parser_string_unify "$(__parser_summary_tag_value "$in_content" "Version")")"
 }
 
 # parser_summary_structure_compatible_value <content>
@@ -534,7 +576,7 @@ parser_summary_version_value() {
 parser_summary_structure_compatible_value() {
     declare in_page_content="$1"
 
-    __parser_summary_tag_value "$in_page_content" "Structure compatible"
+    echo -n "$(__parser_string_unify "$(__parser_summary_tag_value "$in_content" "Structure compatible")")"
 }
 
 
@@ -558,46 +600,6 @@ __parser_summary_tag_definition() {
     [[ "$in_tag" =~ ^(Internal|Deprecated)$ && "$in_tag_value" == false ]] && return "$SUCCESS"
 
     echo -n "> $in_tag: $in_tag_value"
-}
-
-# __parser_string_join <separator> <strings>
-# Output joined strings.
-#
-# Output:
-#   <strings>
-#
-# Return:
-#   - 0 always
-#
-# Notes:
-#   - <string> should not contain trailing \n
-__parser_string_join() {
-  declare in_separator="$1"
-  declare in_string="$2"
-
-  if shift 2; then
-    printf '%s' "$in_string" "${@/#/$in_separator}"
-  fi
-}
-
-# __parser_string_unify <string>
-# Output string without repeated comma-separated items.
-#
-# Output:
-#   <string>
-#
-# Return:
-#   - 0 always
-#
-# Notes:
-#   - <string> should not contain trailing \n
-__parser_string_unify() {
-    declare string="$1"
-
-    mapfile -t string_array < <(echo -n "$string" | sed -E 's/ +/ /g
-    s/ *, */\n/g' | sort -r -u)
-
-    __parser_string_join ", " "${string_array[@]}"
 }
 
 # parser_summary_cleaned_up <content>
@@ -632,17 +634,17 @@ parser_summary_cleaned_up() {
     # shellcheck disable=2155
     declare deprecated="$(parser_summary_deprecated_value_or_default "$in_content")"
     # shellcheck disable=2155
-    declare see_also="$(__parser_string_unify "$(parser_summary_see_also_value "$in_content")")"
+    declare see_also="$(parser_summary_see_also_value "$in_content")"
     # shellcheck disable=2155
-    declare aliases="$(__parser_string_unify "$(parser_summary_aliases_value "$in_content")")"
+    declare aliases="$(parser_summary_aliases_value "$in_content")"
     # shellcheck disable=2155
-    declare syntax_compatible="$(__parser_string_unify "$(parser_summary_syntax_compatible_value "$in_content")")"
+    declare syntax_compatible="$(parser_summary_syntax_compatible_value "$in_content")"
     # shellcheck disable=2155
-    declare help="$(__parser_string_unify "$(parser_summary_help_value "$in_content")")"
+    declare help="$(parser_summary_help_value "$in_content")"
     # shellcheck disable=2155
-    declare version="$(__parser_string_unify "$(parser_summary_version_value "$in_content")")"
+    declare version="$(parser_summary_version_value "$in_content")"
     # shellcheck disable=2155
-    declare structure_compatible="$(__parser_string_unify "$(parser_summary_structure_compatible_value "$in_content")")"
+    declare structure_compatible="$(parser_summary_structure_compatible_value "$in_content")"
     
     echo -n "> $description
 $(__parser_summary_tag_definition "Internal" "$internal")

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -761,3 +761,90 @@ __parser_output_token_type() {
 
     [[ -n "${tokens[line]}" ]] && echo -n "${tokens[line]}"
 }
+
+# parser_output_command_example_description_tokens <page-content> <index>
+# Output command example description tokens for alternatives and literals from a page content.
+#
+# Output:
+#   <command-example-description>
+#
+# Return:
+#   - 0 if page layout, index is valid
+#   - 1 if page layout is invalid
+#   - 20 if index is invalid
+#
+# Notes:
+#   - .clip page content without trailing \n
+#   - alternative parsing is the first parsing stage
+#   - mnemonics are considered to be nested inside alternatives or literals
+parser_output_command_example_description_tokens() {
+    declare in_page_content="$1"
+    declare -i in_index="$2"
+
+    ((in_index < 0)) && return "$INVALID_EXAMPLE_INDEX_FAIL"
+
+    declare description=
+    description="$(parser_output_command_example_description "$in_page_content" "$in_index")"
+    # shellcheck disable=2181
+    (($? == 0)) || return "$?"
+
+    declare tokens=
+    tokens="$(__parser_output_tokenized_by_balanced_tokens "$description" "()")"
+    # shellcheck disable=2181
+    (($? == 0)) || return "$?"
+
+    echo -n "$tokens"
+}
+
+# parser_output_command_example_description_mnemonic_tokens <page-content> <index>
+# Output command example description tokens for mnemonics and literals from a page content.
+#
+# Output:
+#   <command-example-description>
+#
+# Return:
+#   - 0 if page layout, index is valid
+#   - 1 if page layout is invalid
+#   - 20 if index is invalid
+#
+# Notes:
+#   - .clip page content without trailing \n
+#   - mnemonic parsing is the second parsing stage
+#   - alternatives should be already expanded before parsing mnemonics
+parser_output_command_example_description_mnemonic_tokens() {
+    declare in_page_content="$1"
+    declare -i in_index="$2"
+
+    ((in_index < 0)) && return "$INVALID_EXAMPLE_INDEX_FAIL"
+
+    declare description=
+    description="$(parser_output_command_example_description "$in_page_content" "$in_index")"
+    # shellcheck disable=2181
+    (($? == 0)) || return "$?"
+
+    declare tokens=
+    tokens="$(__parser_output_tokenized_by_balanced_tokens "$description" "[]")"
+    # shellcheck disable=2181
+    (($? == 0)) || return "$?"
+
+    echo -n "$tokens"
+}
+
+# parser_output_command_example_description_alternative_tokens <alternative>
+# Output tokens from an alternative.
+#
+# Output:
+#   <alternative-tokens>
+#
+# Return:
+#   - 0 if page layout, index is valid
+#   - 1 if page layout is invalid
+#   - 20 if index is invalid
+#
+# Notes:
+#   - .clip page content without trailing \n
+parser_output_command_example_description_alternative_tokens() {
+    declare in_alternative="$1"
+
+    __parser_output_tokenized_by_unbalanced_tokens "$in_alternative" "|"
+}

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -1390,6 +1390,11 @@ parser_check_examples__code_allows_alternative_expansion() {
     done
 
     ((alternative_count == 1)) || return "$PARSER_NOT_ALLOWED_CODE"
+
+    # shellcheck disable=2155
+    declare alternative_pieces="$(__parser_tokens__all_unbalanced "$description_alternative" "|")"
+    (("$(parser_tokens__count "$alternative_pieces")" < 2)) && return "$PARSER_INVALID_TOKENS_CODE"
+
     # shellcheck disable=2155
     declare -i alternative_piece_count="$(parser_tokens__count "$(parser_examples__description_alternative_token_pieces "$description_alternative")")"
     

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -287,7 +287,7 @@ __parser_summary_tags() {
         s/\.$//
         s/ +$//
         s/ +:$//
-        s/  +/ /g
+        s/ +/ /g
         s/: +/\n/
         p
     }' <<<"$summary")"

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 declare -i SUCCESS=0
-declare -i FAIL=1
 
 # Page validation fails
 declare -i INVALID_LAYOUT_FAIL=1

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -108,7 +108,8 @@ __parser_check_command_summary_correctness() {
 #
 # Return:
 #   - 0 if page layout, command summary is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 10 if command summary is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -169,7 +170,10 @@ __parser_check_command_tag_value_correctness() {
 #
 # Return:
 #   - 0 if page layout, command summary is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 10 if command summary is invalid
+#   - 11 if command tag is invalid
+#   - 12 if tag value is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -206,7 +210,10 @@ __parser_output_command_tags() {
 #
 # Return:
 #   - 0 if page layout, command summary, tag is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 10 if command summary is invalid
+#   - 11 if command tag is invalid
+#   - 12 if tag value is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -244,7 +251,9 @@ __parser_output_command_tag_value() {
 #
 # Return:
 #   - 0 if page layout, command summary is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 10 if command summary is invalid
+#   - 12 if tag value is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -262,7 +271,9 @@ parser_output_command_more_information_tag_value() {
 #
 # Return:
 #   - 0 if page layout, command summary is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 10 if command summary is invalid
+#   - 12 if tag value is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -280,7 +291,9 @@ parser_output_command_internal_tag_value() {
 #
 # Return:
 #   - 0 if page layout, command summary is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 10 if command summary is invalid
+#   - 12 if tag value is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -304,7 +317,9 @@ parser_output_command_internal_tag_value_or_default() {
 #
 # Return:
 #   - 0 if page layout, command summary is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 10 if command summary is invalid
+#   - 12 if tag value is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -322,7 +337,9 @@ parser_output_command_deprecated_tag_value() {
 #
 # Return:
 #   - 0 if page layout, command summary is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 10 if command summary is invalid
+#   - 12 if tag value is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -346,7 +363,9 @@ parser_output_command_deprecated_tag_value_or_default() {
 #
 # Return:
 #   - 0 if page layout, command summary is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 10 if command summary is invalid
+#   - 12 if tag value is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -364,7 +383,9 @@ parser_output_command_see_also_tag_value() {
 #
 # Return:
 #   - 0 if page layout, command summary is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 10 if command summary is invalid
+#   - 12 if tag value is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -382,7 +403,9 @@ parser_output_command_aliases_tag_value() {
 #
 # Return:
 #   - 0 if page layout, command summary is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 10 if command summary is invalid
+#   - 12 if tag value is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -400,7 +423,9 @@ parser_output_command_syntax_compatible_tag_value() {
 #
 # Return:
 #   - 0 if page layout, command summary is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 10 if command summary is invalid
+#   - 12 if tag value is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -418,7 +443,9 @@ parser_output_command_help_tag_value() {
 #
 # Return:
 #   - 0 if page layout, command summary is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 10 if command summary is invalid
+#   - 12 if tag value is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -436,7 +463,9 @@ parser_output_command_version_tag_value() {
 #
 # Return:
 #   - 0 if page layout, command summary is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 10 if command summary is invalid
+#   - 12 if tag value is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -502,7 +531,8 @@ __parser_output_command_example_count() {
 #
 # Return:
 #   - 0 if page layout, index is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 20 if index is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -532,7 +562,8 @@ parser_output_command_example_description() {
 #
 # Return:
 #   - 0 if page layout, index is valid
-#   - 1 otherwise
+#   - 1 if page layout is invalid
+#   - 20 if index is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -155,6 +155,8 @@ __parser_check_command_tag_value_correctness() {
         [[ "$command_tag_value" =~ ^(true|false)$ ]]
     elif [[ "$command_tag" =~ ^(See also|Aliases|Syntax compatible|Structure compatible)$ ]]; then
         ! [[ "$command_tag_value" =~ ,, ]]
+    else
+        [[ "$command_tag" == "More information" ]]
     fi
 }
 

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -834,3 +834,38 @@ parser_output_command_example_description_alternative_tokens() {
 
     __parser_output_tokenized_by_unbalanced_tokens "$in_alternative" "|"
 }
+
+# parser_output_command_example_code_tokens <page-content> <example-index>
+# Output code tokens for placeholders and literals from a specific page content.
+#
+# Output:
+#   <code-tokens>
+#
+# Return:
+#   - 0 if page layout && example index is valid
+#   - 1 if page layout is invalid
+#   - 20 if example index is invalid
+#   - 21 if example description is invalid
+#
+# Notes:
+#   - .clip page content without trailing \n
+#   - alternative parsing is the first parsing stage
+#   - mnemonics are considered to be nested inside alternatives or literals
+parser_output_command_example_code_tokens() {
+    declare in_page_content="$1"
+    declare -i in_example_index="$2"
+
+    ((in_index < 0)) && return "$INVALID_EXAMPLE_INDEX_FAIL"
+
+    declare code=
+    code="$(parser_output_command_example_code "$in_page_content" "$in_example_index")"
+    # shellcheck disable=2181
+    (($? == 0)) || return "$?"
+
+    declare tokens=
+    tokens="$(__parser_output_tokenized_by_balanced_tokens "$code" "{}")"
+    # shellcheck disable=2181
+    (($? == 0)) || return "$?"
+
+    echo -n "$tokens"
+}

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -267,7 +267,7 @@ __parser_output_command_tags() {
 #
 # Notes:
 #   - .clip page content without trailing \n
-__parser_output_command_tag() {
+__parser_output_command_tag_value() {
     declare page_content="$1"
     declare command_tag="$2"
 
@@ -305,10 +305,10 @@ __parser_output_command_tag() {
 #
 # Notes:
 #   - .clip page content without trailing \n
-parser_output_command_more_information_tag() {
+parser_output_command_more_information_tag_value() {
     declare page_content="$1"
 
-    __parser_output_command_tag "$page_content" "More information"
+    __parser_output_command_tag_value "$page_content" "More information"
 }
 
 # parser_output_command_internal_tag <page-content>
@@ -323,10 +323,10 @@ parser_output_command_more_information_tag() {
 #
 # Notes:
 #   - .clip page content without trailing \n
-parser_output_command_internal_tag() {
+parser_output_command_internal_tag_value() {
     declare page_content="$1"
 
-    parser_output_command_tag "$page_content" "Internal"
+    parser_output_command_tag_value "$page_content" "Internal"
 }
 
 # parser_output_command_internal_tag_or_default <page-content>
@@ -341,11 +341,11 @@ parser_output_command_internal_tag() {
 #
 # Notes:
 #   - .clip page content without trailing \n
-parser_output_command_internal_tag_or_default() {
+parser_output_command_internal_tag_value_or_default() {
     declare page_content="$1"
 
     declare output=
-    output="$(parser_output_command_internal_tag "$page_content")"
+    output="$(parser_output_command_internal_tag_value "$page_content")"
     # shellcheck disable=2181
     (($? == 0)) || return "$?"
 
@@ -365,10 +365,10 @@ parser_output_command_internal_tag_or_default() {
 #
 # Notes:
 #   - .clip page content without trailing \n
-parser_output_command_deprecated_tag() {
+parser_output_command_deprecated_tag_value() {
     declare page_content="$1"
 
-    parser_output_command_tag "$page_content" "Deprecated"
+    parser_output_command_tag_value "$page_content" "Deprecated"
 }
 
 # parser_output_command_deprecated_tag_or_default <page-content>
@@ -383,11 +383,11 @@ parser_output_command_deprecated_tag() {
 #
 # Notes:
 #   - .clip page content without trailing \n
-parser_output_command_deprecated_tag_or_default() {
+parser_output_command_deprecated_tag_value_or_default() {
     declare page_content="$1"
 
     declare output=
-    output="$(parser_output_command_deprecated_tag "$page_content")"
+    output="$(parser_output_command_deprecated_tag_value "$page_content")"
     # shellcheck disable=2181
     (($? == 0)) || return "$?"
 
@@ -407,10 +407,10 @@ parser_output_command_deprecated_tag_or_default() {
 #
 # Notes:
 #   - .clip page content without trailing \n
-parser_output_command_see_also_tag() {
+parser_output_command_see_also_tag_value() {
     declare page_content="$1"
 
-    parser_output_command_tag "$page_content" "See also"
+    parser_output_command_tag_value "$page_content" "See also"
 }
 
 # parser_output_command_aliases_tag <page-content>
@@ -425,10 +425,10 @@ parser_output_command_see_also_tag() {
 #
 # Notes:
 #   - .clip page content without trailing \n
-parser_output_command_aliases_tag() {
+parser_output_command_aliases_tag_value() {
     declare page_content="$1"
 
-    parser_output_command_tag "$page_content" "Aliases"
+    parser_output_command_tag_value "$page_content" "Aliases"
 }
 
 # parser_output_command_syntax_compatible_tag <page-content>
@@ -446,7 +446,7 @@ parser_output_command_aliases_tag() {
 parser_output_command_syntax_compatible_tag() {
     declare page_content="$1"
 
-    parser_output_command_tag "$page_content" "Syntax compatible"
+    parser_output_command_tag_value "$page_content" "Syntax compatible"
 }
 
 # parser_output_command_help_tag <page-content>
@@ -461,10 +461,10 @@ parser_output_command_syntax_compatible_tag() {
 #
 # Notes:
 #   - .clip page content without trailing \n
-parser_output_command_help_tag() {
+parser_output_command_help_tag_value() {
     declare page_content="$1"
 
-    parser_output_command_tag "$page_content" "Help"
+    parser_output_command_tag_value "$page_content" "Help"
 }
 
 # parser_output_command_version_tag <page-content>
@@ -479,10 +479,10 @@ parser_output_command_help_tag() {
 #
 # Notes:
 #   - .clip page content without trailing \n
-parser_output_command_version_tag() {
+parser_output_command_version_tag_value() {
     declare page_content="$1"
 
-    parser_output_command_tag "$page_content" "Version"
+    parser_output_command_tag_value "$page_content" "Version"
 }
 
 # parser_output_command_structure_compatible_tag <page-content>
@@ -497,8 +497,8 @@ parser_output_command_version_tag() {
 #
 # Notes:
 #   - .clip page content without trailing \n
-parser_output_command_structure_compatible_tag() {
+parser_output_command_structure_compatible_tag_value() {
     declare page_content="$1"
 
-    parser_output_command_tag "$page_content" "Structure compatible"
+    parser_output_command_tag_value "$page_content" "Structure compatible"
 }

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -3,10 +3,15 @@
 declare -i SUCCESS=0
 declare -i FAIL=1
 
+# Page validation fails
 declare -i INVALID_LAYOUT_FAIL=1
+
+# Summary validation fails
 declare -i INVALID_SUMMARY_FAIL=10
 declare -i INVALID_TAG_FAIL=11
 declare -i INVALID_TAG_VALUE_FAIL=12
+
+# Example validation fails
 declare -i INVALID_EXAMPLE_INDEX_FAIL=20
 declare -i INVALID_CONSTRUCT_FAIL=30
 

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -11,6 +11,12 @@ declare -i PARSER_NOT_ALLOWED_CODE=6
 
 
 
+parser__version() {
+    echo "1.0.0"
+}
+
+
+
 # __parser_string__join <separator> <strings>
 # Output joined strings.
 #

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -308,7 +308,7 @@ __parser_output_command_tag() {
 parser_output_command_more_information_tag() {
     declare page_content="$1"
 
-    parser_output_command_tag "$page_content" "More information"
+    __parser_output_command_tag "$page_content" "More information"
 }
 
 # parser_output_command_internal_tag <page-content>

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -731,3 +731,29 @@ __parser_output_token_value() {
 
     [[ -n "${tokens[line + 1]}" ]] && echo -n "${tokens[line + 1]}"
 }
+
+# __parser_output_token_type <tokens> <index>
+# Output token type from a token list.
+#
+# Output:
+#   <token-type>
+#
+# Return:
+#   - 0 always
+__parser_output_token_type() {
+    declare tokens="$1"
+    declare index="$2"
+
+    declare count="$(__parser_output_token_count "$tokens")"
+    declare -i line=0
+    declare -i current_index=0
+
+    mapfile -t tokens <<<"$tokens"
+
+    while ((line < count * 2)) && ((current_index != index)); do
+        line+=2
+        current_index+=1
+    done
+
+    [[ -n "${tokens[line]}" ]] && echo -n "${tokens[line]}"
+}

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -605,7 +605,7 @@ __parser_output_current_token() {
         [[ "${in_string:in_index:1}" == \\ ]] && in_index+=1
 
         current_token+="${in_string:in_index:1}"
-        index+=1
+        in_index+=1
     done
 
     echo -n "$current_token"
@@ -650,8 +650,10 @@ __parser_output_tokenized_by_balanced_tokens() {
         construct_token="$(__parser_output_current_token "$in_string" "$index" "$construct_end")"
         index="$?"
 
-        [[ "${in_string:index:1}" != "$construct_end" ]] && return "$INVALID_CONSTRUCT_FAIL"
-        [[ -n "$construct_token" ]] && printf "%s\n%s\n" CONSTRUCT "$construct_token"
+        [[ -n "$construct_token" ]] && {
+            [[ "${in_string:index:1}" != "$construct_end" ]] && return "$INVALID_CONSTRUCT_FAIL"
+            printf "%s\n%s\n" CONSTRUCT "$construct_token"
+        }
         index+=1
     done
 }

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -979,3 +979,50 @@ parser_check_command_example_code_placeholder_alternative_allow_repetitions() {
     ! sed -nE '/^(\/|\/\?)?[^ *+?]+([*+?]| +([[:digit:]]+\.\.[[:digit:]]+|[[:digit:]]+\.\.|\.\.[[:digit:]]+))!/! Q1' <<<"$in_placeholder_alternative_content" ||
         return "$INVALID_PLACEHOLDER_ALTERNATIVE_REPETITION_NOT_ALLOWED"
 }
+
+# parser_output_command_example_code_placeholder_alternative_description <placeholder-alternative>
+# Output an alternative description for a specific placeholder alternative.
+#
+# Output:
+#   <alternative-description>
+#
+# Return:
+#   - 0 if placeholder alternative is valid
+#   - 24 otherwise
+#
+# Notes:
+#   - placeholder without trailing \n
+parser_output_command_example_code_placeholder_alternative_description() {
+    declare in_alternative_content="$1"
+
+    __parser_check_command_example_code_placeholder_alternative_correctness "$in_alternative_content" ||
+        return "$INVALID_PLACEHOLDER_ALTERNATIVE_FAIL"
+    
+    in_alternative_content="$(sed -E 's/^(\/|\/\?)?[^ *+?]+([*+?]!?| +([[:digit:]]+\.\.[[:digit:]]+|[[:digit:]]+\.\.|\.\.[[:digit:]]+)!?)? +//' <<<"$in_alternative_content")"
+    
+    echo -n "$(__parser_output_current_token "$in_alternative_content" 0 ":")"
+}
+
+# parser_output_command_example_code_placeholder_alternative_description <placeholder-alternative>
+# Output an alternative description for a specific placeholder alternative.
+#
+# Output:
+#   <alternative-description>
+#
+# Return:
+#   - 0 if placeholder alternative is valid
+#   - 24 otherwise
+#
+# Notes:
+#   - placeholder without trailing \n
+parser_output_command_example_code_placeholder_alternative_examples() {
+    declare in_alternative_content="$1"
+
+    __parser_check_command_example_code_placeholder_alternative_correctness "$in_alternative_content" ||
+        return "$INVALID_PLACEHOLDER_ALTERNATIVE_FAIL"
+    
+    # shellcheck disable=2155
+    declare alternative_description="$(__parser_output_current_token "$in_alternative_content" 0 ":")"
+    declare -i description_length="${#alternative_description} + 1"
+    echo -n "$(sed -E 's/^ +//' <<< "${in_alternative_content:description_length}")"
+}

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -10,39 +10,6 @@ declare -i INVALID_TAG_VALUE_FAIL=12
 declare -i INVALID_EXAMPLE_INDEX_FAIL=20
 declare -i INVALID_CONSTRUCT_FAIL=30
 
-declare PARSER_ERROR_PREFIX="${PARSER_ERROR_PREFIX:-$(basename "$0")}"
-
-# parser_print_message <source> <message>
-# Print message.
-#
-# Output:
-#   <empty-string>
-#
-# Return:
-#   - 0 always
-parser_print_message() {
-    declare in_source="$1"
-    declare in_message="$2"
-
-    echo -e "$PARSER_ERROR_PREFIX: $in_source: ${SUCCESS_COLOR}$in_message$RESET_COLOR" >&2
-}
-
-# parser_throw_error <source> <message>
-# Output error message and fail.
-#
-# Output:
-#   <empty-string>
-#
-# Return:
-#   - $FAIL always
-parser_throw_error() {
-    declare in_source="$1"
-    declare in_message="$2"
-
-    echo -e "$PARSER_ERROR_PREFIX: $in_source: ${ERROR_COLOR}$in_message$RESET_COLOR" >&2
-    exit "$FAIL"
-}
-
 # __parser_check_layout_correctness <page-content>
 # Check whether a page content is valid.
 #

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -10,66 +10,6 @@ declare -i INVALID_TAG_VALUE_FAIL=4
 
 declare PARSER_ERROR_PREFIX="${PARSER_ERROR_PREFIX:-$(basename "$0")}"
 
-__parser_color_to_code() {
-    declare color="$1"
-
-    case "$color" in
-    red)
-        echo -n 31
-        ;;
-    green)
-        echo -n 32
-        ;;
-    yellow)
-        echo -n 33
-        ;;
-    blue)
-        echo -n 34
-        ;;
-    magenta)
-        echo -n 35
-        ;;
-    cyan)
-        echo -n 36
-        ;;
-    light-gray)
-        echo -n 37
-        ;;
-    gray)
-        echo -n 90
-        ;;
-    light-red)
-        echo -n 91
-        ;;
-    light-green)
-        echo -n 92
-        ;;
-    light-yellow)
-        echo -n 93
-        ;;
-    light-blue)
-        echo -n 94
-        ;;
-    light-magenta)
-        echo -n 95
-        ;;
-    light-cyan)
-        echo -n 96
-        ;;
-    white)
-        echo -n 97
-        ;;
-    *)
-        echo -n 0
-        ;;
-    esac
-}
-
-# Error colors:
-declare RESET_COLOR="\e[$(__parser_color_to_code none)m"
-declare ERROR_COLOR="\e[$(__parser_color_to_code red)m"
-declare SUCCESS_COLOR="\e[$(__parser_color_to_code green)m"
-
 # parser_print_message <source> <message>
 # Print message.
 #

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -15,6 +15,7 @@ declare -i INVALID_TAG_VALUE_FAIL=12
 declare -i INVALID_EXAMPLE_INDEX_FAIL=20
 declare -i INVALID_CONSTRUCT_FAIL=21
 declare -i INVALID_TOKEN_INDEX_FAIL=22
+declare -i INVALID_TOKEN_VALUE_FAIL=23
 
 # __parser_check_layout_correctness <page-content>
 # Check whether a specific page content is valid.
@@ -793,6 +794,7 @@ parser_output_command_example_description_tokens() {
 #   - 1 if page layout is invalid
 #   - 20 if example index is invalid
 #   - 21 if example description is invalid
+#   - 23 if description mnemonic is invalid
 #
 # Notes:
 #   - .clip page content without trailing \n
@@ -813,6 +815,23 @@ parser_output_command_example_description_mnemonic_tokens() {
     tokens="$(__parser_output_tokenized_by_balanced_tokens "$description" "[]")"
     # shellcheck disable=2181
     (($? == 0)) || return "$?"
+
+    # shellcheck disable=2155
+    declare -i count="$(__parser_output_token_count "$tokens")"
+
+    declare -i index=0
+
+    # shellcheck disable=2155
+    while ((index < count)); do
+        declare token_type="$(__parser_output_token_type "$tokens" "$index")"
+        declare token_value="$(__parser_output_token_value "$tokens" "$index")"
+
+        if [[ "$token_type" == CONSTRUCT ]] && [[ "$token_value" =~ ' ' ]]; then
+            return "$INVALID_TOKEN_VALUE_FAIL"
+        fi
+
+        index+=1
+    done
 
     echo -n "$tokens"
 }

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -479,7 +479,7 @@ __parser_output_command_examples() {
 #
 # Notes:
 #   - .clip page content without trailing \n
-__parser_output_command_examples_count() {
+__parser_output_command_example_count() {
     declare page_content="$1"
 
     declare examples=
@@ -518,7 +518,7 @@ parser_output_command_example_description() {
     (($? == 0)) || return "$?"
 
     # shellcheck disable=2155
-    declare -i count="$(__parser_output_command_examples_count "$page_content")"
+    declare -i count="$(__parser_output_command_example_count "$page_content")"
     ((index >= count)) && return "$INVALID_EXAMPLE_INDEX_FAIL"
 
     sed -nE "$((index * 2 + 1)) p" <<<"$examples"
@@ -548,7 +548,7 @@ parser_output_command_example_code() {
     (($? == 0)) || return "$?"
 
     # shellcheck disable=2155
-    declare -i count="$(__parser_output_command_examples_count "$page_content")"
+    declare -i count="$(__parser_output_command_example_count "$page_content")"
     ((index >= count)) && return "$INVALID_EXAMPLE_INDEX_FAIL"
 
     sed -nE "$((index * 2 + 2)) p" <<<"$examples"

--- a/clip-parse/clip-parse.sh
+++ b/clip-parse/clip-parse.sh
@@ -444,11 +444,3 @@ parser_output_command_structure_compatible_tag_value() {
 
     __parser_output_command_tag_value "$page_content" "Structure compatible"
 }
-parser_output_command_description '# some
-
-> Some  text.
-> More information: https://example.com.
-
-- Some text:
-
-`some`'

--- a/clip-parse/tests/checks/layout.bats
+++ b/clip-parse/tests/checks/layout.bats
@@ -7,7 +7,7 @@
     ! __parser_check_layout_correctness '# some
 
 > Some text.
-> More information https://example.com
+> More information: https://example.com
 
 - Some text:
 
@@ -23,7 +23,7 @@
 # some
 
 > Some text.
-> More information https://example.com
+> More information: https://example.com
 
 - Some text:
 
@@ -38,7 +38,7 @@
 
 
 > Some text.
-> More information https://example.com
+> More information: https://example.com
 
 - Some text:
 
@@ -50,7 +50,7 @@
     source ./clip-parse.sh
 
     ! __parser_check_layout_correctness '> Some text.
-> More information https://example.com
+> More information: https://example.com
 
 - Some text:
 
@@ -75,7 +75,7 @@
     ! __parser_check_layout_correctness '# some
 
 > Some text.
-> More information https://example.com'
+> More information: https://example.com'
 }
 
 # bats test_tags=invalid, no-valid-order
@@ -83,7 +83,7 @@
     source ./clip-parse.sh
 
     ! __parser_check_layout_correctness '> Some text.
-> More information https://example.com
+> More information: https://example.com
 
 # some
 
@@ -99,7 +99,7 @@
     __parser_check_layout_correctness '# some
 
 > Some text.
-> More information https://example.com
+> More information: https://example.com
 
 - Some text:
 

--- a/clip-parse/tests/checks/layout.bats
+++ b/clip-parse/tests/checks/layout.bats
@@ -78,6 +78,20 @@
 > More information https://example.com.'
 }
 
+# bats test_tags=invalid, no-valid-order
+@test "expect error when invalid layout with invalid order passed" {
+    source ./clip-parse.sh
+
+    ! __parser_check_layout_correctness '> Some text.
+> More information https://example.com.
+
+# some
+
+- Some text:
+
+`some`'
+}
+
 # bats test_tags=valid, layout
 @test "expect no error when valid page passed" {
     source ./clip-parse.sh

--- a/clip-parse/tests/checks/layout.bats
+++ b/clip-parse/tests/checks/layout.bats
@@ -92,7 +92,7 @@
 `some`'
 }
 
-# bats test_tags=valid, all
+# bats test_tags=valid, other
 @test "expect no error when valid page passed" {
     source ./clip-parse.sh
 

--- a/clip-parse/tests/checks/layout.bats
+++ b/clip-parse/tests/checks/layout.bats
@@ -7,7 +7,7 @@
     ! __parser_check_layout_correctness '# some
 
 > Some text.
-> More information https://example.com.
+> More information https://example.com
 
 - Some text:
 
@@ -23,7 +23,7 @@
 # some
 
 > Some text.
-> More information https://example.com.
+> More information https://example.com
 
 - Some text:
 
@@ -38,7 +38,7 @@
 
 
 > Some text.
-> More information https://example.com.
+> More information https://example.com
 
 - Some text:
 
@@ -50,7 +50,7 @@
     source ./clip-parse.sh
 
     ! __parser_check_layout_correctness '> Some text.
-> More information https://example.com.
+> More information https://example.com
 
 - Some text:
 
@@ -75,7 +75,7 @@
     ! __parser_check_layout_correctness '# some
 
 > Some text.
-> More information https://example.com.'
+> More information https://example.com'
 }
 
 # bats test_tags=invalid, no-valid-order
@@ -83,7 +83,7 @@
     source ./clip-parse.sh
 
     ! __parser_check_layout_correctness '> Some text.
-> More information https://example.com.
+> More information https://example.com
 
 # some
 
@@ -99,7 +99,7 @@
     __parser_check_layout_correctness '# some
 
 > Some text.
-> More information https://example.com.
+> More information https://example.com
 
 - Some text:
 

--- a/clip-parse/tests/checks/layout.bats
+++ b/clip-parse/tests/checks/layout.bats
@@ -78,7 +78,7 @@
 > More information https://example.com.'
 }
 
-# bats test_tags=invalid, no-valid-order
+# bats test_tags=invalid, invalid-order
 @test "expect error when invalid layout with invalid order passed" {
     source ./clip-parse.sh
 

--- a/clip-parse/tests/checks/layout.bats
+++ b/clip-parse/tests/checks/layout.bats
@@ -78,7 +78,7 @@
 > More information https://example.com.'
 }
 
-# bats test_tags=invalid, invalid-order
+# bats test_tags=invalid, no-valid-order
 @test "expect error when invalid layout with invalid order passed" {
     source ./clip-parse.sh
 

--- a/clip-parse/tests/checks/layout.bats
+++ b/clip-parse/tests/checks/layout.bats
@@ -92,7 +92,7 @@
 `some`'
 }
 
-# bats test_tags=valid, layout
+# bats test_tags=valid, all
 @test "expect no error when valid page passed" {
     source ./clip-parse.sh
 

--- a/clip-parse/tests/checks/summary.bats
+++ b/clip-parse/tests/checks/summary.bats
@@ -80,7 +80,7 @@
 '
 }
 
-# bats test_tags=valid, all
+# bats test_tags=valid, other
 @test "expect no error when valid summary passed" {
     source ./clip-parse.sh
 
@@ -88,7 +88,7 @@
 > More information: https://example.com'
 }
 
-# bats test_tags=valid, all
+# bats test_tags=valid, other
 @test "expect no error when valid summary with description lines passed" {
     source ./clip-parse.sh
 
@@ -97,7 +97,7 @@
 > More information: https://example.com'
 }
 
-# bats test_tags=valid, all
+# bats test_tags=valid, other
 @test "expect no error when valid summary with several tags passed" {
     source ./clip-parse.sh
 

--- a/clip-parse/tests/checks/summary.bats
+++ b/clip-parse/tests/checks/summary.bats
@@ -5,7 +5,7 @@
     source ./clip-parse.sh
 
     ! __parser_check_command_summary_correctness '> Some text.
-> More information: https://example.com.
+> More information: https://example.com
 '
 }
 
@@ -15,7 +15,7 @@
 
     ! __parser_check_command_summary_correctness '
 > Some text.
-> More information: https://example.com.'
+> More information: https://example.com'
 }
 
 # bats test_tags=invalid, extra-newlines
@@ -24,7 +24,17 @@
 
     ! __parser_check_command_summary_correctness '> Some text.
 
-> More information: https://example.com.'
+> More information: https://example.com'
+}
+
+# bats test_tags=invalid, extra-description-lines
+@test "expect error when invalid summary with several extra description lines passed" {
+    source ./clip-parse.sh
+
+    ! __parser_check_command_summary_correctness '> Some text.
+> Some text.
+> Some text.
+> More information: https://example.com'
 }
 
 # bats test_tags=invalid, no-description
@@ -33,7 +43,7 @@
 
     ! __parser_check_command_summary_correctness '# some
 
-> More information: https://example.com.
+> More information: https://example.com
 
 - Some text:
 
@@ -55,13 +65,13 @@
 '
 }
 
-# bats test_tags=invalid, invalid-order
+# bats test_tags=invalid, no-valid-order
 @test "expect error when invalid summary with invalid order passed" {
     source ./clip-parse.sh
 
     ! __parser_check_command_summary_correctness '# some
 
-> More information: https://example.com.
+> More information: https://example.com
 > Some text.
 
 - Some text:
@@ -70,10 +80,28 @@
 '
 }
 
-# bats test_tags=valid, summary
+# bats test_tags=valid, all
 @test "expect no error when valid summary passed" {
     source ./clip-parse.sh
 
     __parser_check_command_summary_correctness '> Some text.
-> More information: https://example.com.'
+> More information: https://example.com'
+}
+
+# bats test_tags=valid, all
+@test "expect no error when valid summary with description lines passed" {
+    source ./clip-parse.sh
+
+    __parser_check_command_summary_correctness '> Some text.
+> Some text.
+> More information: https://example.com'
+}
+
+# bats test_tags=valid, all
+@test "expect no error when valid summary with several tags passed" {
+    source ./clip-parse.sh
+
+    __parser_check_command_summary_correctness '> Some text.
+> Internal: true
+> More information: https://example.com'
 }

--- a/clip-parse/tests/checks/summary.tags.bats
+++ b/clip-parse/tests/checks/summary.tags.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+# bats test_tags=invalid, extra-spaces
+@test "expect error when invalid tag with trailing space passed" {
+    source ./clip-parse.sh
+
+    ! __parser_check_command_tag_correctness 'More information '
+}
+
+# bats test_tags=invalid, extra-spaces
+@test "expect error when invalid tag with leading space passed" {
+    source ./clip-parse.sh
+
+    ! __parser_check_command_tag_correctness ' More information'
+}
+
+# bats test_tags=invalid, extra-spaces
+@test "expect error when invalid tag with several spaces passed" {
+    source ./clip-parse.sh
+
+    ! __parser_check_command_tag_correctness 'More  information'
+}
+
+# bats test_tags=invalid, no-valid-tag
+@test "expect error when invalid tag passed" {
+    source ./clip-parse.sh
+
+    ! __parser_check_command_tag_correctness 'Invalid'
+}
+
+# bats test_tags=valid, all
+@test "expect error when valid tag passed" {
+    source ./clip-parse.sh
+
+    __parser_check_command_tag_correctness 'More information'
+}

--- a/clip-parse/tests/checks/summary.tags.bats
+++ b/clip-parse/tests/checks/summary.tags.bats
@@ -28,7 +28,7 @@
     ! __parser_check_command_tag_correctness 'Invalid'
 }
 
-# bats test_tags=valid, all
+# bats test_tags=valid, other
 @test "expect error when valid tag passed" {
     source ./clip-parse.sh
 

--- a/clip-parse/tests/checks/summary.tags.values.bats
+++ b/clip-parse/tests/checks/summary.tags.values.bats
@@ -21,7 +21,7 @@
     ! __parser_check_command_tag_value_correctness 'Invalid' 'Some text.'
 }
 
-# bats test_tags=valid, all
+# bats test_tags=valid, other
 @test "expect error when valid tag value value passed" {
     source ./clip-parse.sh
 

--- a/clip-parse/tests/checks/summary.tags.values.bats
+++ b/clip-parse/tests/checks/summary.tags.values.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+# bats test_tags=invalid, extra-spaces
+@test "expect error when invalid tag value with trailing space passed" {
+    source ./clip-parse.sh
+
+    ! __parser_check_command_tag_value_correctness 'Internal' 'true '
+}
+
+# bats test_tags=invalid, extra-spaces
+@test "expect error when invalid tag value with leading space passed" {
+    source ./clip-parse.sh
+
+    ! __parser_check_command_tag_value_correctness 'Internal' ' true'
+}
+
+# bats test_tags=invalid, no-valid-tag
+@test "expect error when invalid tag passed" {
+    source ./clip-parse.sh
+
+    ! __parser_check_command_tag_value_correctness 'Invalid' 'Some text.'
+}
+
+# bats test_tags=valid, all
+@test "expect error when valid tag value value passed" {
+    source ./clip-parse.sh
+
+    __parser_check_command_tag_value_correctness 'Internal' true
+}

--- a/clip-parse/tests/extractors/header.bats
+++ b/clip-parse/tests/extractors/header.bats
@@ -64,7 +64,6 @@
     [[ "$output" == "some command with subcommand" ]]
 }
 
-
 # bats test_tags=valid, other
 @test "expect no error when valid header passed" {
     source ./clip-parse.sh

--- a/clip-parse/tests/extractors/header.bats
+++ b/clip-parse/tests/extractors/header.bats
@@ -7,7 +7,7 @@
     ! parser_output_command_with_subcommands '# some
 
 > Some text.
-> More information https://example.com.
+> More information: https://example.com
 
 - Some text:
 
@@ -22,7 +22,7 @@
     ! parser_output_command_with_subcommands '## some
 
 > Some text.
-> More information https://example.com.
+> More information: https://example.com
 
 - Some text:
 
@@ -30,14 +30,64 @@
 '
 }
 
+# bats test_tags=valid, extra-spaces
+@test "expect no error when valid header with trailing space passed" {
+    source ./clip-parse.sh
+
+    run parser_output_command_with_subcommands '# some command with subcommand 
+
+> Some text.
+> More information: https://example.com
+
+- Some text:
+
+`some`'
+
+    [[ "$output" == "some command with subcommand" ]]
+}
+
+
+# bats test_tags=valid, extra-spaces
+@test "expect no error when valid header with leading space passed" {
+    source ./clip-parse.sh
+
+    run parser_output_command_with_subcommands '#  some command with subcommand
+
+> Some text.
+> More information: https://example.com
+
+- Some text:
+
+`some`'
+
+    [[ "$output" == "some command with subcommand" ]]
+}
+
+# bats test_tags=valid, extra-spaces
+@test "expect no error when valid header with several spaces space passed" {
+    source ./clip-parse.sh
+
+    run parser_output_command_with_subcommands '# some  command with subcommand 
+
+> Some text.
+> More information: https://example.com
+
+- Some text:
+
+`some`'
+
+    [[ "$output" == "some command with subcommand" ]]
+}
+
+
 # bats test_tags=valid, header
 @test "expect no error when valid header passed" {
     source ./clip-parse.sh
 
-    run parser_output_command_with_subcommands '#  some  command with  subcommand 
+    run parser_output_command_with_subcommands '# some command with  subcommand
 
 > Some text.
-> More information https://example.com.
+> More information: https://example.com
 
 - Some text:
 

--- a/clip-parse/tests/extractors/header.bats
+++ b/clip-parse/tests/extractors/header.bats
@@ -65,7 +65,7 @@
 }
 
 
-# bats test_tags=valid, header
+# bats test_tags=valid, other
 @test "expect no error when valid header passed" {
     source ./clip-parse.sh
 

--- a/clip-parse/tests/extractors/header.bats
+++ b/clip-parse/tests/extractors/header.bats
@@ -15,21 +15,6 @@
 '
 }
 
-# bats test_tags=invalid, extra-level
-@test "expect error when invalid header with second level passed" {
-    source ./clip-parse.sh
-
-    ! parser_output_command_with_subcommands '## some
-
-> Some text.
-> More information: https://example.com
-
-- Some text:
-
-`some`
-'
-}
-
 # bats test_tags=valid, extra-spaces
 @test "expect no error when valid header with trailing space passed" {
     source ./clip-parse.sh

--- a/clip-parse/tests/extractors/summary.description.bats
+++ b/clip-parse/tests/extractors/summary.description.bats
@@ -7,7 +7,6 @@
     ! parser_output_command_description '# some
 
 > Some text.
-> See also: other.
 > More information: https://example.com.
 
 - Some text:
@@ -29,14 +28,78 @@
 `some`'
 }
 
-# bats test_tags=valid, summary, description
-@test "expect no error when valid summary passed" {
+# bats test_tags=valid, summary, extra-spaces
+@test "expect no error when valid description with trailing space passed" {
+    source ./clip-parse.sh
+
+    run parser_output_command_description '# some
+
+> Some text. 
+> More information: https://example.com.
+
+- Some text:
+
+`some`'
+
+    [[ "$output" == "Some text." ]]
+}
+
+# bats test_tags=valid, summary, extra-spaces
+@test "expect no error when valid description with leading space passed" {
+    source ./clip-parse.sh
+
+    run parser_output_command_description '# some
+
+>  Some text.
+> More information: https://example.com.
+
+- Some text:
+
+`some`'
+
+    [[ "$output" == "Some text." ]]
+}
+
+# bats test_tags=valid, summary, extra-spaces
+@test "expect no error when valid description with several spaces passed" {
+    source ./clip-parse.sh
+
+    run parser_output_command_description '# some
+
+> Some  text.
+> More information: https://example.com.
+
+- Some text:
+
+`some`'
+
+    [[ "$output" == "Some text." ]]
+}
+
+# bats test_tags=valid, summary, extra-description-lines
+@test "expect no error when valid header with several extra description lines passed" {
     source ./clip-parse.sh
 
     run parser_output_command_description '# some
 
 > Some text.
-> See also: other.
+> Some text.
+> More information: https://example.com.
+
+- Some text:
+
+`some`'
+
+    [[ "$output" == $'Some text.\nSome text.' ]]
+}
+
+# bats test_tags=valid, summary, description
+@test "expect no error when valid description passed" {
+    source ./clip-parse.sh
+
+    run parser_output_command_description '# some
+
+> Some text.
 > More information: https://example.com.
 
 - Some text:

--- a/clip-parse/tests/extractors/summary.tags.bats
+++ b/clip-parse/tests/extractors/summary.tags.bats
@@ -4,7 +4,7 @@
 @test "expect error when invalid layout passed" {
     source ./clip-parse.sh
 
-    ! __parser_output_command_tags '# some
+    declare page_content='# some
 
 > Some text.
 > See also: other.
@@ -14,34 +14,96 @@
 
 `some`
 '
+
+    ! parser_output_command_aliases_tag_value "$page_content"
+    ! parser_output_command_deprecated_tag_value "$page_content"
+    ! parser_output_command_deprecated_tag_value_or_default "$page_content"
+    ! parser_output_command_help_tag_value "$page_content"
+    ! parser_output_command_internal_tag_value "$page_content"
+    ! parser_output_command_internal_tag_value_or_default "$page_content"
+    ! parser_output_command_more_information_tag_value "$page_content"
+    ! parser_output_command_see_also_tag_value "$page_content"
+    ! parser_output_command_structure_compatible_tag_value "$page_content"
+    ! parser_output_command_syntax_compatible_tag_value "$page_content"
+    ! parser_output_command_version_tag_value "$page_content"
 }
 
 # bats test_tags=invalid, external
 @test "expect error when invalid summary passed" {
     source ./clip-parse.sh
 
-    ! __parser_output_command_tags '# some
+    declare page_content='# some
 
 > Some text.
 
 - Some text:
 
 `some`'
+
+    ! parser_output_command_aliases_tag_value "$page_content"
+    ! parser_output_command_deprecated_tag_value "$page_content"
+    ! parser_output_command_deprecated_tag_value_or_default "$page_content"
+    ! parser_output_command_help_tag_value "$page_content"
+    ! parser_output_command_internal_tag_value "$page_content"
+    ! parser_output_command_internal_tag_value_or_default "$page_content"
+    ! parser_output_command_more_information_tag_value "$page_content"
+    ! parser_output_command_see_also_tag_value "$page_content"
+    ! parser_output_command_structure_compatible_tag_value "$page_content"
+    ! parser_output_command_syntax_compatible_tag_value "$page_content"
+    ! parser_output_command_version_tag_value "$page_content"
 }
 
 # bats test_tags=valid, summary, description
 @test "expect no error when valid summary passed" {
     source ./clip-parse.sh
 
-    run __parser_output_command_tags '# some
+declare page_content='# some
 
 > Some text.
-> See also: other.
-> More information: https://example.com.
+> Aliases: egrep
+> Deprecated: true
+> Help: --help
+> Internal: true
+> More information: https://example.com
+> See also: awk
+> Structure compatible: /bin
+> Syntax compatible: sh
+> Version: --version
 
 - Some text:
 
 `some`'
 
-    [[ "$output" == $'See also\nother.\nMore information\nhttps://example.com.' ]]
+    run parser_output_command_aliases_tag_value "$page_content"
+    [[ "$output" == egrep ]]
+
+    run parser_output_command_deprecated_tag_value "$page_content"
+    [[ "$output" == true ]]
+
+    run parser_output_command_deprecated_tag_value_or_default "$page_content"
+    [[ "$output" == true ]]
+
+    run parser_output_command_help_tag_value "$page_content"
+    [[ "$output" == --help ]]
+
+    run parser_output_command_internal_tag_value "$page_content"
+    [[ "$output" == true ]]
+
+    run parser_output_command_internal_tag_value_or_default "$page_content"
+    [[ "$output" == true ]]
+
+    run parser_output_command_more_information_tag_value "$page_content"
+    [[ "$output" == "https://example.com" ]]
+
+    run parser_output_command_see_also_tag_value "$page_content"
+    [[ "$output" == awk ]]
+
+    run parser_output_command_structure_compatible_tag_value "$page_content"
+    [[ "$output" == "/bin" ]]
+
+    run parser_output_command_syntax_compatible_tag_value "$page_content"
+    [[ "$output" == sh ]]
+
+    run parser_output_command_version_tag_value "$page_content"
+    [[ "$output" == --version ]]
 }


### PR DESCRIPTION
closes #19 

## ToDo

Now the following things are parsed:

- [x] command header
- [x] command summary (with tags and description)
  - [ ] function to tokenize command description as it permits mnemonics
- [x] command examples
- [x] converting to representation with mnemonics and placeholders
- [x] redesign naming convention to make names more concise



Layout, summary and other things are validated in each get request. At the basic level all parser API functions check page layout. But if there are additional checks available for the requested item (like summary) then they are done too.

## Usage

### API usage
Extracting info about the first placeholder in the first example:

```bash
declare page='# grep

> Find patterns in files using regular expressions
> More information: https://www.gnu.org/software/grep/manual/grep.html

- Search for a pattern within a file:

`grep "{string value: foo[12]}" {file value}`

- Search for an exact string (disables regular expressions):

`grep --fixed-strings "{string value: blabla}" {file value}`'

declare tokens="$(parser_output_command_example_code_tokens "$page" 0)"
declare first_placeholder="$(__parser_output_token_value "$tokens" 1)"
echo "placeholder type: $(parser_output_command_example_code_placeholder_alternative_type "$first_placeholder")"
echo "placeholder explanation: $(parser_output_command_example_code_placeholder_alternative_description "$first_placeholder")"
echo "placeholder examples: $(parser_output_command_example_code_placeholder_alternative_examples "$first_placeholder")"
```

![image](https://user-images.githubusercontent.com/42812113/222432114-4550b802-2876-4bfb-9b8b-af061c30623f.png)

### Example expansion in action

Input page:

```md
# [[

> Check file types and compare values
> Returns 0 if the condition evaluates to true, 1 if it evaluates to false
> More information: https://www.gnu.org/software/bash/manual/bash.html#index-test

- Test if a specific variable is (equal|not equal) to a string:

`[[ "${string variable: foo}" {string operator: ==|string operator: !=} "{string string: Hello world!}" ]]`

- Test if a specific variable is ([eq]ual|[n]ot [e]qual|[g]reater [t]han|[l]ess [t]han|[g]reater than or [e]qual|[l]ess than or [e]qual) to a number:

`[[ "${string variable: foo}" {string operator: -eq|string operator: -ne|string operator: -gt|string operator: -lt|string operator: -ge|string operator: -le} {string number: 1} ]]`' 0
echo "STATUS = $?"
```

Output page (just examples):

```md
- Test if a specific variable is equal to a string:

`[[ "${string variable: foo}" {string operator: ==} "{string string: Hello world!}" ]]`

- Test if a specific variable is not equal to a string:

`[[ "${string variable: foo}" {string operator: !=} "{string string: Hello world!}" ]]`

- Test if a specific variable is [eq]ual to a number:

`[[ "${string variable: foo}" {string operator: -eq} {string number: 1} ]]`

- Test if a specific variable is [n]ot [e]qual to a number:

`[[ "${string variable: foo}" {string operator: -ne} {string number: 1} ]]`

- Test if a specific variable is [g]reater [t]han to a number:

`[[ "${string variable: foo}" {string operator: -gt} {string number: 1} ]]`

- Test if a specific variable is [l]ess [t]han to a number:

`[[ "${string variable: foo}" {string operator: -lt} {string number: 1} ]]`

- Test if a specific variable is [g]reater than or [e]qual to a number:

`[[ "${string variable: foo}" {string operator: -ge} {string number: 1} ]]`

- Test if a specific variable is [l]ess than or [e]qual to a number:

`[[ "${string variable: foo}" {string operator: -le} {string number: 1} ]]`
```